### PR TITLE
Return content of extensions tag as XML to the user

### DIFF
--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -10,29 +10,40 @@ use parser::Context;
 
 /// consume consumes the entire content of the extension tag and returns as string
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<(String)> {
-    let mut extension_xml : Option<String> = None;
+    let mut extension_xml: Option<String> = None;
     let mut depth = 1; //this consume function is called when the opening extension tag was already read (except in tests)
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
-                if &name.local_name == "extensions" && depth == 1 { //needed because tests have this tag in, actual parsing has it stripped already
+                if &name.local_name == "extensions" && depth == 1 {
+                    //needed because tests have this tag in, actual parsing has it stripped already
                     continue;
                 }
-                ensure!(&name.local_name != "extensions", "extensions tag opened twice");
-                extension_xml = Some(extension_xml.unwrap_or("".to_string()) + "<" + &name.borrow().to_repr() + ">");
+                ensure!(
+                    &name.local_name != "extensions",
+                    "extensions tag opened twice"
+                );
+                extension_xml = Some(
+                    extension_xml.unwrap_or("".to_string()) + "<" + &name.borrow().to_repr() + ">",
+                );
                 depth += 1;
             }
 
-            XmlEvent::Characters(content) => extension_xml = Some(extension_xml.unwrap_or("".to_string()) + &content),
+            XmlEvent::Characters(content) => {
+                extension_xml = Some(extension_xml.unwrap_or("".to_string()) + &content)
+            }
 
             XmlEvent::EndElement { name, .. } => {
                 depth -= 1;
                 ensure!(depth >= 0, "extensions tag contained invalid xml");
-                if &name.local_name == "extensions"  {
+                if &name.local_name == "extensions" {
                     ensure!(depth == 0, "extensions tag contained invalid xml");
                     return extension_xml.ok_or("no content inside extensions".into());
                 } else {
-                    extension_xml = Some(extension_xml.unwrap_or("".to_string()) + "</" +  &name.borrow().to_repr() + ">");
+                    extension_xml = Some(
+                        extension_xml.unwrap_or("".to_string()) + "</" + &name.borrow().to_repr()
+                            + ">",
+                    );
                 }
             }
 

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -8,24 +8,31 @@ use xml::reader::XmlEvent;
 
 use parser::Context;
 
-/// consume consumes a single string as tag content.
-pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
-    let mut started = false;
-
+/// consume consumes the entire content of the extension tag and returns as string
+pub fn consume<R: Read>(context: &mut Context<R>) -> Result<(String)> {
+    let mut extension_xml : Option<String> = None;
+    let mut depth = 1; //this consume function is called when the opening extension tag was already read (except in tests)
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
-                // flip started depending on conditions
-                if &name.local_name == "extensions" {
-                    ensure!(!started, "extensions tag opened twice");
-
-                    started = true;
+                if &name.local_name == "extensions" && depth == 1 { //needed because tests have this tag in, actual parsing has it stripped already
+                    continue;
                 }
+                ensure!(&name.local_name != "extensions", "extensions tag opened twice");
+                extension_xml = Some(extension_xml.unwrap_or("".to_string()) + "<" + &name.borrow().to_repr() + ">");
+                depth += 1;
             }
 
+            XmlEvent::Characters(content) => extension_xml = Some(extension_xml.unwrap_or("".to_string()) + &content),
+
             XmlEvent::EndElement { name, .. } => {
-                if &name.local_name == "extensions" {
-                    return Ok(());
+                depth -= 1;
+                ensure!(depth >= 0, "extensions tag contained invalid xml");
+                if &name.local_name == "extensions"  {
+                    ensure!(depth == 0, "extensions tag contained invalid xml");
+                    return extension_xml.ok_or("no content inside extensions".into());
+                } else {
+                    extension_xml = Some(extension_xml.unwrap_or("".to_string()) + "</" +  &name.borrow().to_repr() + ">");
                 }
             }
 

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -40,6 +40,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Waypoint> {
     let mut pdop: Option<f64> = None; // Position dilution of precision (decimal)
     let mut age_of_gps_data: Option<f64> = None; // Seconds since last DGPS update (decimal)
     let mut dgpsid: Option<u16> = None; // Id of the DGPS station (integer 0-1023)
+    let mut extension_xml: Option<String> = None; //xml-string, to be parsed by user
 
     while let Some(event) = context.reader.next() {
         match event.chain_err(|| "error while parsing XML")? {
@@ -130,7 +131,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Waypoint> {
                     }
 
                     // Finally the GPX 1.1 extensions
-                    "extensions" => extensions::consume(context)?,
+                    "extensions" => extension_xml = Some(extensions::consume(context)?),
                     child => Err(Error::from(ErrorKind::InvalidChildElement(
                         String::from(child),
                         "waypoint",
@@ -160,6 +161,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Waypoint> {
                 wpt.speed = speed;
                 wpt.age = age_of_gps_data;
                 wpt.dgpsid = dgpsid;
+                wpt.extension_xml = extension_xml;
 
                 return Ok(wpt);
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -243,7 +243,10 @@ pub struct Waypoint {
 
     /// ID of DGPS station used in differential correction, in the range [0, 1023].
     pub dgpsid: Option<u16>,
-    // <extensions> extensionsType </extensions> [0..1] ?
+
+    /// XML-String containing the value of the extensions tag. Usually needs
+    /// to be parsed by the user, according to the specific extension format.
+    pub extension_xml: Option<String>,
 }
 
 impl Waypoint {
@@ -305,6 +308,7 @@ impl Waypoint {
             pdop: None,
             age: None,
             dgpsid: None,
+            extension_xml: None,
         }
     }
 }


### PR DESCRIPTION
A solution to Issue #8, gives Waypoint a new field called "extension_xml", which contains the XML String that was contained in the extensions Tag, if present. The user will need to parse this String according to his needs.