### PR TITLE
implement writing of GPX files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,13 +45,15 @@ extern crate xml;
 #[cfg(test)]
 extern crate geo;
 
-// Export our type structs in the root, along with the read function.
+// Export our type structs in the root, along with the read and write functions.
 pub use reader::read;
 pub use types::*;
+pub use writer::write;
 
 mod parser;
 mod reader;
 mod types;
+mod writer;
 
 // Errors should be namespaced away.
 pub mod errors;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,319 @@
+//! Writes an activity to GPX format.
+
+use std::io::Write;
+
+use chrono::prelude::Utc;
+use chrono::DateTime;
+
+use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
+
+use geo_types::Rect;
+
+use errors::*;
+use types::*;
+use Gpx;
+use GpxVersion;
+
+/// Writes an activity to GPX format.
+///
+/// Takes any `std::io::Write` as its writer, and returns a
+/// `std::io::Result<()>`.
+///
+/// ```
+/// use gpx::write;
+/// use gpx::Gpx;
+/// use gpx::GpxVersion;
+///
+/// let mut data : Gpx = Default::default();
+/// data.version = GpxVersion::Gpx11;
+///
+/// // You can give it anything that implements `std::io::Write`.
+/// write(&data, std::io::stdout()).unwrap();
+/// ```
+pub fn write<W: Write>(gpx: &Gpx, writer: W) -> Result<()> {
+    let mut writer = EmitterConfig::new()
+        .perform_indent(true)
+        .create_writer(writer);
+    write_xml_event(
+        XmlEvent::start_element("gpx")
+            .attr("version", version_to_version_string(gpx.version)?)
+            .attr("creator", "https://github.com/georust/gpx"),
+        &mut writer,
+    )?;
+    write_metadata(gpx, &mut writer)?;
+    for point in &gpx.waypoints {
+        write_waypoint("wpt", point, &mut writer)?;
+    }
+    for track in &gpx.tracks {
+        write_track(track, &mut writer)?;
+    }
+    write_xml_event(XmlEvent::end_element(), &mut writer)?;
+    Ok(())
+}
+
+fn write_xml_event<'a, W, E>(event: E, writer: &mut EventWriter<W>) -> Result<()>
+where
+    W: Write,
+    E: Into<XmlEvent<'a>>,
+{
+    writer
+        .write(event)
+        .chain_err(|| Error::from("error while writing gpx event"))
+}
+
+fn version_to_version_string(version: GpxVersion) -> Result<&'static str> {
+    match version {
+        GpxVersion::Gpx10 => Ok("1.0"),
+        GpxVersion::Gpx11 => Ok("1.1"),
+        version => Err(Error::from(format!("Unknown version {:?}", version))),
+    }
+}
+
+fn write_metadata<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>) -> Result<()> {
+    match gpx.version {
+        GpxVersion::Gpx10 => write_gpx10_metadata(gpx, writer),
+        GpxVersion::Gpx11 => write_gpx11_metadata(gpx, writer),
+        version => Err(Error::from(format!("Unknown version {:?}", version))),
+    }
+}
+
+fn write_gpx10_metadata<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>) -> Result<()> {
+    if gpx.metadata.is_none() {
+        return Ok(());
+    }
+    let metadata = gpx.metadata.as_ref().unwrap();
+    write_string_if_exists("name", &metadata.name, writer)?;
+    write_string_if_exists("description", &metadata.description, writer)?;
+    if let Some(author) = metadata.author.as_ref() {
+        write_string_if_exists("author", &author.name, writer)?;
+        write_email_if_exists(&author.email, writer)?;
+        if let Some(link) = author.link.as_ref() {
+            write_string("url", &link.href, writer)?;
+            write_string_if_exists("urlname", &link.text, writer)?;
+        }
+    }
+    write_string_if_exists("keywords", &metadata.keywords, writer)?;
+    write_time_if_exists(&metadata.time, writer)?;
+    write_bounds_if_exists(&metadata.bounds, writer)?;
+    Ok(())
+}
+
+fn write_gpx11_metadata<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>) -> Result<()> {
+    if gpx.metadata.is_none() {
+        return Ok(());
+    }
+    let metadata = gpx.metadata.as_ref().unwrap();
+    write_xml_event(XmlEvent::start_element("metadata"), writer)?;
+    write_string_if_exists("name", &metadata.name, writer)?;
+    write_string_if_exists("description", &metadata.description, writer)?;
+    write_person_if_exists("author", &metadata.author, writer)?;
+    write_string_if_exists("keywords", &metadata.keywords, writer)?;
+    write_time_if_exists(&metadata.time, writer)?;
+    for link in &metadata.links {
+        write_link(&link, writer)?;
+    }
+    write_bounds_if_exists(&metadata.bounds, writer)?;
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}
+
+fn write_string<W: Write>(key: &str, value: &str, writer: &mut EventWriter<W>) -> Result<()> {
+    write_xml_event(XmlEvent::start_element(key), writer)?;
+    write_xml_event(XmlEvent::characters(value), writer)?;
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}
+
+fn write_string_if_exists<W: Write>(
+    key: &str,
+    value: &Option<String>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref value) = value {
+        write_string(key, value, writer)?;
+    }
+    Ok(())
+}
+
+fn write_value_if_exists<W: Write, T: ToString>(
+    key: &str,
+    value: &Option<T>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref value) = value {
+        write_xml_event(XmlEvent::start_element(key), writer)?;
+        let value = &value.to_string();
+        write_xml_event(XmlEvent::characters(value), writer)?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_email_if_exists<W: Write>(
+    email: &Option<String>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref email) = email {
+        let mut parts = email.split("@");
+        let id = parts.next().ok_or("Missing id part in email!")?;
+        let domain = parts.next().ok_or("Missing domain part in email!")?;
+        if parts.next().is_some() {
+            bail!(ErrorKind::Msg(format!(
+                "Email contains more than one @: {}",
+                email
+            )));
+        }
+        write_xml_event(
+            XmlEvent::start_element("email")
+                .attr("id", id)
+                .attr("domain", domain),
+            writer,
+        )?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_link<W: Write>(link: &Link, writer: &mut EventWriter<W>) -> Result<()> {
+    write_xml_event(
+        XmlEvent::start_element("link").attr("href", &link.href),
+        writer,
+    )?;
+    write_string_if_exists("text", &link.text, writer)?;
+    write_string_if_exists("type", &link._type, writer)?;
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}
+
+fn write_link_if_exists<W: Write>(link: &Option<Link>, writer: &mut EventWriter<W>) -> Result<()> {
+    if let Some(ref link) = link {
+        write_link(link, writer)?;
+    }
+    Ok(())
+}
+
+fn write_person_if_exists<W: Write>(
+    key: &str,
+    value: &Option<Person>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref value) = value {
+        write_xml_event(XmlEvent::start_element(key), writer)?;
+        write_string_if_exists("name", &value.name, writer)?;
+        write_email_if_exists(&value.email, writer)?;
+        write_link_if_exists(&value.link, writer)?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_time_if_exists<W: Write>(
+    time: &Option<DateTime<Utc>>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref time) = time {
+        write_xml_event(XmlEvent::start_element("time"), writer)?;
+        write_xml_event(XmlEvent::characters(&time.to_rfc3339()), writer)?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_bounds_if_exists<W: Write>(
+    bounds: &Option<Rect<f64>>,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    if let Some(ref bounds) = bounds {
+        write_xml_event(
+            XmlEvent::start_element("bounds")
+                .attr("minlat", &bounds.min.y.to_string())
+                .attr("maxlat", &bounds.max.y.to_string())
+                .attr("minlon", &bounds.min.x.to_string())
+                .attr("maxlon", &bounds.max.x.to_string()),
+            writer,
+        )?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_fix_if_exists<W: Write>(fix: &Option<Fix>, writer: &mut EventWriter<W>) -> Result<()> {
+    if let Some(ref fix) = fix {
+        write_xml_event(XmlEvent::start_element("fix"), writer)?;
+        let fix_str = match fix {
+            Fix::None => "none",
+            Fix::TwoDimensional => "2d",
+            Fix::ThreeDimensional => "3d",
+            Fix::DGPS => "dgps",
+            Fix::PPS => "pps",
+            Fix::Other(string) => string,
+        };
+        write_xml_event(XmlEvent::characters(fix_str), writer)?;
+        write_xml_event(XmlEvent::end_element(), writer)?;
+    }
+    Ok(())
+}
+
+fn write_track<W: Write>(track: &Track, writer: &mut EventWriter<W>) -> Result<()> {
+    write_xml_event(XmlEvent::start_element("trk"), writer)?;
+    write_string_if_exists("name", &track.name, writer)?;
+    write_string_if_exists("cmt", &track.comment, writer)?;
+    write_string_if_exists("desc", &track.description, writer)?;
+    write_string_if_exists("src", &track.source, writer)?;
+    for link in &track.links {
+        write_link(link, writer)?;
+    }
+    write_string_if_exists("type", &track._type, writer)?;
+    for segment in &track.segments {
+        write_track_segment(segment, writer)?;
+    }
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}
+
+fn write_track_segment<W: Write>(
+    segment: &TrackSegment,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    write_xml_event(XmlEvent::start_element("trkseg"), writer)?;
+    for point in &segment.points {
+        write_waypoint("trkpt", point, writer)?;
+    }
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}
+
+fn write_waypoint<W: Write>(
+    tagname: &str,
+    waypoint: &Waypoint,
+    writer: &mut EventWriter<W>,
+) -> Result<()> {
+    write_xml_event(
+        XmlEvent::start_element(tagname)
+            .attr("lat", &waypoint.point().lat().to_string())
+            .attr("lon", &waypoint.point().lng().to_string()),
+        writer,
+    )?;
+    write_value_if_exists("ele", &waypoint.elevation, writer)?;
+    // TODO: write speed if GPX version == 1.0
+    write_time_if_exists(&waypoint.time, writer)?;
+    write_value_if_exists("geoidheight", &waypoint.geoidheight, writer)?;
+    write_string_if_exists("name", &waypoint.name, writer)?;
+    write_string_if_exists("cmt", &waypoint.comment, writer)?;
+    write_string_if_exists("desc", &waypoint.description, writer)?;
+    write_string_if_exists("src", &waypoint.source, writer)?;
+    for link in &waypoint.links {
+        write_link(link, writer)?;
+    }
+    write_string_if_exists("sym", &waypoint.symbol, writer)?;
+    write_string_if_exists("type", &waypoint._type, writer)?;
+    write_fix_if_exists(&waypoint.fix, writer)?;
+    write_value_if_exists("sat", &waypoint.sat, writer)?;
+    write_value_if_exists("hdop", &waypoint.hdop, writer)?;
+    write_value_if_exists("vdop", &waypoint.vdop, writer)?;
+    write_value_if_exists("pdop", &waypoint.pdop, writer)?;
+    write_value_if_exists("ageofdgpsdata", &waypoint.age, writer)?;
+    write_value_if_exists("dgpsid", &waypoint.dgpsid, writer)?;
+    write_xml_event(XmlEvent::end_element(), writer)?;
+    Ok(())
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -312,7 +312,7 @@ fn write_waypoint<W: Write>(
     write_value_if_exists("hdop", &waypoint.hdop, writer)?;
     write_value_if_exists("vdop", &waypoint.vdop, writer)?;
     write_value_if_exists("pdop", &waypoint.pdop, writer)?;
-    write_value_if_exists("ageofdgpsdata", &waypoint.age, writer)?;
+    write_value_if_exists("ageofgpsdata", &waypoint.age, writer)?;
     write_value_if_exists("dgpsid", &waypoint.dgpsid, writer)?;
     write_xml_event(XmlEvent::end_element(), writer)?;
     Ok(())

--- a/tests/gpx_write.rs
+++ b/tests/gpx_write.rs
@@ -1,0 +1,128 @@
+extern crate geo;
+extern crate geo_types;
+extern crate gpx;
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use gpx::read;
+    use gpx::write;
+    use gpx::Gpx;
+    use gpx::Link;
+    use gpx::Waypoint;
+
+    #[test]
+    fn gpx_writer_write_unknown_gpx_version() {
+        let gpx: Gpx = Default::default();
+        let mut writer: Vec<u8> = Vec::new();
+        // Should fail with unknown version.
+        let result = write(&gpx, &mut writer);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn gpx_writer_write_test_wikipedia() {
+        check_write_for_example_file("tests/fixtures/wikipedia_example.gpx");
+    }
+
+    #[test]
+    fn gpx_writer_write_test_garmin_activity() {
+        check_write_for_example_file("tests/fixtures/garmin-activity.gpx");
+    }
+
+    #[test]
+    fn gpx_writer_write_test_with_accuracy() {
+        check_write_for_example_file("tests/fixtures/with_accuracy.gpx");
+    }
+
+    fn check_write_for_example_file(filename: &str) {
+        let reference_gpx = read_test_gpx_file(filename);
+        let written_gpx = write_and_reread_gpx(&reference_gpx);
+
+        check_metadata_equal(&reference_gpx, &written_gpx);
+        check_points_equal(&reference_gpx, &written_gpx);
+    }
+
+    fn read_test_gpx_file(filename: &str) -> Gpx {
+        let file = File::open(filename).unwrap();
+        let reader = BufReader::new(file);
+
+        let result = read(reader);
+        assert!(result.is_ok());
+
+        result.unwrap()
+    }
+
+    fn write_and_reread_gpx(reference_gpx: &Gpx) -> Gpx {
+        let mut buffer: Vec<u8> = Vec::new();
+        let result = write(&reference_gpx, &mut buffer);
+        assert!(result.is_ok());
+
+        let written_gpx = read(buffer.as_slice()).unwrap();
+        written_gpx
+    }
+
+    fn check_metadata_equal(reference_gpx: &Gpx, written_gpx: &Gpx) {
+        let reference = &reference_gpx.metadata;
+        let written = &written_gpx.metadata;
+        if reference.is_some() {
+            assert!(written.is_some());
+        } else {
+            assert!(written.is_none());
+            return;
+        }
+        let reference = reference.as_ref().unwrap();
+        let written = written.as_ref().unwrap();
+        assert_eq!(reference.name, written.name);
+        assert_eq!(reference.time, written.time);
+        check_links_equal(&reference.links, &written.links);
+    }
+
+    fn check_links_equal(reference: &Vec<Link>, written: &Vec<Link>) {
+        assert_eq!(reference.len(), written.len());
+        for (r, w) in reference.iter().zip(written) {
+            assert_eq!(r.href, w.href);
+            assert_eq!(r.text, w.text);
+        }
+    }
+
+    fn check_points_equal(reference: &Gpx, written: &Gpx) {
+        check_waypoints_equal(&reference.waypoints, &written.waypoints);
+        assert_eq!(reference.tracks.len(), written.tracks.len());
+        for (r_track, w_track) in reference.tracks.iter().zip(written.tracks.iter()) {
+            assert_eq!(r_track.name, w_track.name);
+            assert_eq!(r_track.segments.len(), w_track.segments.len());
+            for (r_seg, w_seg) in r_track.segments.iter().zip(w_track.segments.iter()) {
+                check_waypoints_equal(&r_seg.points, &w_seg.points);
+            }
+        }
+    }
+
+    fn check_waypoints_equal(reference: &Vec<Waypoint>, written: &Vec<Waypoint>) {
+        assert_eq!(reference.len(), written.len());
+        for (r_wp, w_wp) in reference.iter().zip(written) {
+            assert_eq!(r_wp.point(), w_wp.point());
+            assert_eq!(r_wp.elevation, w_wp.elevation);
+            assert_eq!(r_wp.speed, w_wp.speed);
+            assert_eq!(r_wp.time, w_wp.time);
+            assert_eq!(r_wp.geoidheight, w_wp.geoidheight);
+            assert_eq!(r_wp.name, w_wp.name);
+            assert_eq!(r_wp.comment, w_wp.comment);
+            assert_eq!(r_wp.description, w_wp.description);
+            assert_eq!(r_wp.source, w_wp.source);
+            check_links_equal(&r_wp.links, &w_wp.links);
+            assert_eq!(r_wp.symbol, w_wp.symbol);
+            assert_eq!(r_wp._type, w_wp._type);
+            assert_eq!(r_wp.fix, w_wp.fix);
+            assert_eq!(r_wp.sat, w_wp.sat);
+            assert_eq!(r_wp.hdop, w_wp.hdop);
+            assert_eq!(r_wp.vdop, w_wp.vdop);
+            assert_eq!(r_wp.pdop, w_wp.pdop);
+            assert_eq!(r_wp.age, w_wp.age);
+            assert_eq!(r_wp.dgpsid, w_wp.dgpsid);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `gpx::write` function that writes a given `Gpx` object into an object implementing the `Write` trait. This can be used to write GPX data to a .gpx file.

Depending on the version set in the `Gpx` object it writes GPX 1.1 or 1.0 data.

Closes #19.