### PR TITLE
allow empty fields: "desc", "cmt", "description", "keywords", "src"

### DIFF
--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -10,7 +10,7 @@ use types::Fix;
 
 /// consume consumes an element as a fix.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
-    let fix_string = string::consume(context, "fix")?;
+    let fix_string = string::consume(context, "fix", false)?;
 
     let fix = match fix_string.as_ref() {
         "none" => Fix::None,

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -81,25 +81,25 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                     bounds = Some(bounds::consume(context)?);
                 }
                 "author" if context.version == GpxVersion::Gpx10 => {
-                    author = Some(string::consume(context, "author")?);
+                    author = Some(string::consume(context, "author", false)?);
                 }
                 "email" if context.version == GpxVersion::Gpx10 => {
-                    email = Some(string::consume(context, "email")?);
+                    email = Some(string::consume(context, "email", false)?);
                 }
                 "url" if context.version == GpxVersion::Gpx10 => {
-                    url = Some(string::consume(context, "url")?);
+                    url = Some(string::consume(context, "url", false)?);
                 }
                 "urlname" if context.version == GpxVersion::Gpx10 => {
-                    urlname = Some(string::consume(context, "urlname")?);
+                    urlname = Some(string::consume(context, "urlname", false)?);
                 }
                 "name" if context.version == GpxVersion::Gpx10 => {
-                    gpx_name = Some(string::consume(context, "name")?);
+                    gpx_name = Some(string::consume(context, "name", false)?);
                 }
                 "description" if context.version == GpxVersion::Gpx10 => {
-                    description = Some(string::consume(context, "description")?);
+                    description = Some(string::consume(context, "description", true)?);
                 }
                 "keywords" if context.version == GpxVersion::Gpx10 => {
-                    keywords = Some(string::consume(context, "keywords")?);
+                    keywords = Some(string::consume(context, "keywords", true)?);
                 }
                 child => {
                     bail!(ErrorKind::InvalidChildElement(String::from(child), "gpx"));

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -36,8 +36,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
 
         match next_event.chain_err(|| Error::from("error while parsing link event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "text" => link.text = Some(string::consume(context, "text")?),
-                "type" => link._type = Some(string::consume(context, "type")?),
+                "text" => link.text = Some(string::consume(context, "text", false)?),
+                "type" => link._type = Some(string::consume(context, "type", false)?),
                 child => {
                     bail!(ErrorKind::InvalidChildElement(String::from(child), "link"));
                 }

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -31,16 +31,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
         match next_event.chain_err(|| Error::from("error while parsing metadata event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
-                    metadata.name = Some(string::consume(context, "name")?);
+                    metadata.name = Some(string::consume(context, "name", false)?);
                 }
                 "description" => {
-                    metadata.description = Some(string::consume(context, "description")?);
+                    metadata.description = Some(string::consume(context, "description", true)?);
                 }
                 "author" => {
                     metadata.author = Some(person::consume(context, "author")?);
                 }
                 "keywords" => {
-                    metadata.keywords = Some(string::consume(context, "keywords")?);
+                    metadata.keywords = Some(string::consume(context, "keywords", true)?);
                 }
                 "time" => {
                     metadata.time = Some(time::consume(context)?);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,6 +18,14 @@ macro_rules! consume {
             $tagname,
         )
     }};
+    ($xml:expr, $version:expr, $tagname:expr, $allow_empty:expr) => {{
+        use parser::create_context;
+        consume(
+            &mut create_context(BufReader::new($xml.as_bytes()), $version),
+            $tagname,
+            $allow_empty,
+        )
+    }};
 }
 
 pub mod bounds;
@@ -62,7 +70,7 @@ impl<R: Read> Context<R> {
 pub fn verify_starting_tag<R: Read>(
     context: &mut Context<R>,
     local_name: &'static str,
-) -> Result<(Vec<OwnedAttribute>)> {
+) -> Result<Vec<OwnedAttribute>> {
     //makes sure the specified starting tag is the next tag on the stream
     //we ignore and skip all xmlevents except StartElement, Characters and EndElement
     loop {

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -27,7 +27,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 
         match next_event.chain_err(|| Error::from("error while parsing person event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "name" => person.name = Some(string::consume(context, "name")?),
+                "name" => person.name = Some(string::consume(context, "name", false)?),
                 "email" => person.email = Some(email::consume(context)?),
                 "link" => person.link = Some(link::consume(context)?),
                 child => {

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -8,7 +8,11 @@ use parser::verify_starting_tag;
 use parser::Context;
 
 /// consume consumes a single string as tag content.
-pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str, allow_empty: bool) -> Result<String> {
+pub fn consume<R: Read>(
+    context: &mut Context<R>,
+    tagname: &'static str,
+    allow_empty: bool,
+) -> Result<String> {
     let mut string: Option<String> = None;
     if allow_empty {
         string = Some("".to_string());

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -50,7 +50,12 @@ mod tests {
 
     #[test]
     fn consume_simple_string() {
-        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11, "string", false);
+        let result = consume!(
+            "<string>hello world</string>",
+            GpxVersion::Gpx11,
+            "string",
+            false
+        );
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "hello world");

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn consume_simple_string() {
-        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11, "string");
+        let result = consume!("<string>hello world</string>", GpxVersion::Gpx11, "string", false);
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "hello world");
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn consume_new_tag() {
         // cannot start new tag inside string
-        let result = consume!("<foo>bar<baz></baz></foo>", GpxVersion::Gpx11, "foo");
+        let result = consume!("<foo>bar<baz></baz></foo>", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
     }
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn consume_start_tag() {
         // must have starting tag
-        let result = consume!("bar</foo>", GpxVersion::Gpx11, "foo");
+        let result = consume!("bar</foo>", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
     }
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn consume_end_tag() {
         // must have ending tag
-        let result = consume!("<foo>bar", GpxVersion::Gpx11, "foo");
+        let result = consume!("<foo>bar", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
     }
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn consume_no_body() {
         // must have string content
-        let result = consume!("<foo></foo>", GpxVersion::Gpx11, "foo");
+        let result = consume!("<foo></foo>", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
     }
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn consume_different_ending_tag() {
         // this is just illegal
-        let result = consume!("<foo></foobar>", GpxVersion::Gpx11, "foo");
+        let result = consume!("<foo></foobar>", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
     }

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -8,8 +8,11 @@ use parser::verify_starting_tag;
 use parser::Context;
 
 /// consume consumes a single string as tag content.
-pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<String> {
+pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str, allow_empty: bool) -> Result<String> {
     let mut string: Option<String> = None;
+    if allow_empty {
+        string = Some("".to_string());
+    }
     verify_starting_tag(context, tagname)?;
 
     for event in context.reader() {

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -12,7 +12,7 @@ use parser::Context;
 
 /// consume consumes an element as a time.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
-    let time = string::consume(context, "time")?;
+    let time = string::consume(context, "time", false)?;
 
     let time =
         DateTime::parse_from_rfc3339(&time).chain_err(|| "error while parsing time as RFC3339")?;

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -29,19 +29,19 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
         match next_event.chain_err(|| Error::from("error while parsing track event"))? {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
-                    track.name = Some(string::consume(context, "name")?);
+                    track.name = Some(string::consume(context, "name", false)?);
                 }
                 "cmt" => {
-                    track.comment = Some(string::consume(context, "cmt")?);
+                    track.comment = Some(string::consume(context, "cmt", true)?);
                 }
                 "desc" => {
-                    track.description = Some(string::consume(context, "desc")?);
+                    track.description = Some(string::consume(context, "desc", true)?);
                 }
                 "src" => {
-                    track.source = Some(string::consume(context, "src")?);
+                    track.source = Some(string::consume(context, "src", true)?);
                 }
                 "type" => {
-                    track._type = Some(string::consume(context, "type")?);
+                    track._type = Some(string::consume(context, "type", false)?);
                 }
                 "trkseg" => {
                     track.segments.push(tracksegment::consume(context)?);

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -67,7 +67,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
                 "ele" => {
                     // Cast the elevation to an f64, from a string.
                     waypoint.elevation = Some(
-                        string::consume(context, "ele")?
+                        string::consume(context, "ele", false)?
                             .parse()
                             .chain_err(|| "error while casting elevation to f64")?,
                     )
@@ -75,63 +75,63 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
                 "speed" if context.version == GpxVersion::Gpx10 => {
                     // Speed is from GPX 1.0
                     waypoint.speed = Some(
-                        string::consume(context, "speed")?
+                        string::consume(context, "speed", false)?
                             .parse()
                             .chain_err(|| "error while casting speed to f64")?,
                     );
                 }
                 "time" => waypoint.time = Some(time::consume(context)?),
-                "name" => waypoint.name = Some(string::consume(context, "name")?),
-                "cmt" => waypoint.comment = Some(string::consume(context, "cmt")?),
-                "desc" => waypoint.description = Some(string::consume(context, "desc")?),
-                "src" => waypoint.source = Some(string::consume(context, "src")?),
+                "name" => waypoint.name = Some(string::consume(context, "name", false)?),
+                "cmt" => waypoint.comment = Some(string::consume(context, "cmt", true)?),
+                "desc" => waypoint.description = Some(string::consume(context, "desc", true)?),
+                "src" => waypoint.source = Some(string::consume(context, "src", true)?),
                 "link" => waypoint.links.push(link::consume(context)?),
-                "sym" => waypoint.symbol = Some(string::consume(context, "sym")?),
-                "type" => waypoint._type = Some(string::consume(context, "type")?),
+                "sym" => waypoint.symbol = Some(string::consume(context, "sym", false)?),
+                "type" => waypoint._type = Some(string::consume(context, "type", false)?),
 
                 // Optional accuracy information
                 "fix" => waypoint.fix = Some(fix::consume(context)?),
                 "geoidheight" => {
                     waypoint.geoidheight = Some(
-                        string::consume(context, "geoidheight")?
+                        string::consume(context, "geoidheight", false)?
                             .parse()
                             .chain_err(|| "error while casting geoid (geoidheight) to f64")?,
                     )
                 }
                 "sat" => {
                     waypoint.sat =
-                        Some(string::consume(context, "sat")?.parse().chain_err(|| {
+                        Some(string::consume(context, "sat", false)?.parse().chain_err(|| {
                             "error while casting number of satellites (sat) to u64"
                         })?)
                 }
                 "hdop" => {
                     waypoint.hdop =
-                        Some(string::consume(context, "hdop")?.parse().chain_err(|| {
+                        Some(string::consume(context, "hdop", false)?.parse().chain_err(|| {
                             "error while casting horizontal dilution of precision (hdop) to f64"
                         })?)
                 }
                 "vdop" => {
                     waypoint.vdop =
-                        Some(string::consume(context, "vdop")?.parse().chain_err(|| {
+                        Some(string::consume(context, "vdop", false)?.parse().chain_err(|| {
                             "error while casting vertical dilution of precision (vdop) to f64"
                         })?)
                 }
                 "pdop" => {
                     waypoint.pdop =
-                        Some(string::consume(context, "pdop")?.parse().chain_err(|| {
+                        Some(string::consume(context, "pdop", false)?.parse().chain_err(|| {
                             "error while casting position dilution of precision (pdop) to f64"
                         })?)
                 }
                 "ageofgpsdata" => {
                     waypoint.age = Some(
-                        string::consume(context, "ageofgpsdata")?
+                        string::consume(context, "ageofgpsdata", false)?
                             .parse()
                             .chain_err(|| "error while casting age of GPS data to f64")?,
                     )
                 }
                 "dgpsid" => {
                     waypoint.dgpsid = Some(
-                        string::consume(context, "dgpsid")?
+                        string::consume(context, "dgpsid", false)?
                             .parse()
                             .chain_err(|| "error while casting DGPS station ID to u16")?,
                     )

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -63,89 +63,94 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
         };
 
         match next_event.chain_err(|| Error::from("error while parsing waypoint event"))? {
-            XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "ele" => {
-                    // Cast the elevation to an f64, from a string.
-                    waypoint.elevation = Some(
-                        string::consume(context, "ele", false)?
-                            .parse()
-                            .chain_err(|| "error while casting elevation to f64")?,
-                    )
-                }
-                "speed" if context.version == GpxVersion::Gpx10 => {
-                    // Speed is from GPX 1.0
-                    waypoint.speed = Some(
-                        string::consume(context, "speed", false)?
-                            .parse()
-                            .chain_err(|| "error while casting speed to f64")?,
-                    );
-                }
-                "time" => waypoint.time = Some(time::consume(context)?),
-                "name" => waypoint.name = Some(string::consume(context, "name", false)?),
-                "cmt" => waypoint.comment = Some(string::consume(context, "cmt", true)?),
-                "desc" => waypoint.description = Some(string::consume(context, "desc", true)?),
-                "src" => waypoint.source = Some(string::consume(context, "src", true)?),
-                "link" => waypoint.links.push(link::consume(context)?),
-                "sym" => waypoint.symbol = Some(string::consume(context, "sym", false)?),
-                "type" => waypoint._type = Some(string::consume(context, "type", false)?),
+            XmlEvent::StartElement { ref name, .. } => {
+                match name.local_name.as_ref() {
+                    "ele" => {
+                        // Cast the elevation to an f64, from a string.
+                        waypoint.elevation = Some(
+                            string::consume(context, "ele", false)?
+                                .parse()
+                                .chain_err(|| "error while casting elevation to f64")?,
+                        )
+                    }
+                    "speed" if context.version == GpxVersion::Gpx10 => {
+                        // Speed is from GPX 1.0
+                        waypoint.speed = Some(
+                            string::consume(context, "speed", false)?
+                                .parse()
+                                .chain_err(|| "error while casting speed to f64")?,
+                        );
+                    }
+                    "time" => waypoint.time = Some(time::consume(context)?),
+                    "name" => waypoint.name = Some(string::consume(context, "name", false)?),
+                    "cmt" => waypoint.comment = Some(string::consume(context, "cmt", true)?),
+                    "desc" => waypoint.description = Some(string::consume(context, "desc", true)?),
+                    "src" => waypoint.source = Some(string::consume(context, "src", true)?),
+                    "link" => waypoint.links.push(link::consume(context)?),
+                    "sym" => waypoint.symbol = Some(string::consume(context, "sym", false)?),
+                    "type" => waypoint._type = Some(string::consume(context, "type", false)?),
 
-                // Optional accuracy information
-                "fix" => waypoint.fix = Some(fix::consume(context)?),
-                "geoidheight" => {
-                    waypoint.geoidheight = Some(
-                        string::consume(context, "geoidheight", false)?
+                    // Optional accuracy information
+                    "fix" => waypoint.fix = Some(fix::consume(context)?),
+                    "geoidheight" => {
+                        waypoint.geoidheight = Some(
+                            string::consume(context, "geoidheight", false)?
+                                .parse()
+                                .chain_err(|| "error while casting geoid (geoidheight) to f64")?,
+                        )
+                    }
+                    "sat" => {
+                        waypoint.sat =
+                            Some(string::consume(context, "sat", false)?.parse().chain_err(
+                                || "error while casting number of satellites (sat) to u64",
+                            )?)
+                    }
+                    "hdop" => waypoint.hdop = Some(
+                        string::consume(context, "hdop", false)?
                             .parse()
-                            .chain_err(|| "error while casting geoid (geoidheight) to f64")?,
-                    )
-                }
-                "sat" => {
-                    waypoint.sat =
-                        Some(string::consume(context, "sat", false)?.parse().chain_err(|| {
-                            "error while casting number of satellites (sat) to u64"
-                        })?)
-                }
-                "hdop" => {
-                    waypoint.hdop =
-                        Some(string::consume(context, "hdop", false)?.parse().chain_err(|| {
-                            "error while casting horizontal dilution of precision (hdop) to f64"
-                        })?)
-                }
-                "vdop" => {
-                    waypoint.vdop =
-                        Some(string::consume(context, "vdop", false)?.parse().chain_err(|| {
-                            "error while casting vertical dilution of precision (vdop) to f64"
-                        })?)
-                }
-                "pdop" => {
-                    waypoint.pdop =
-                        Some(string::consume(context, "pdop", false)?.parse().chain_err(|| {
-                            "error while casting position dilution of precision (pdop) to f64"
-                        })?)
-                }
-                "ageofgpsdata" => {
-                    waypoint.age = Some(
-                        string::consume(context, "ageofgpsdata", false)?
+                            .chain_err(|| {
+                                "error while casting horizontal dilution of precision (hdop) to f64"
+                            })?,
+                    ),
+                    "vdop" => waypoint.vdop = Some(
+                        string::consume(context, "vdop", false)?
                             .parse()
-                            .chain_err(|| "error while casting age of GPS data to f64")?,
-                    )
-                }
-                "dgpsid" => {
-                    waypoint.dgpsid = Some(
-                        string::consume(context, "dgpsid", false)?
+                            .chain_err(|| {
+                                "error while casting vertical dilution of precision (vdop) to f64"
+                            })?,
+                    ),
+                    "pdop" => waypoint.pdop = Some(
+                        string::consume(context, "pdop", false)?
                             .parse()
-                            .chain_err(|| "error while casting DGPS station ID to u16")?,
-                    )
-                }
+                            .chain_err(|| {
+                                "error while casting position dilution of precision (pdop) to f64"
+                            })?,
+                    ),
+                    "ageofgpsdata" => {
+                        waypoint.age = Some(
+                            string::consume(context, "ageofgpsdata", false)?
+                                .parse()
+                                .chain_err(|| "error while casting age of GPS data to f64")?,
+                        )
+                    }
+                    "dgpsid" => {
+                        waypoint.dgpsid = Some(
+                            string::consume(context, "dgpsid", false)?
+                                .parse()
+                                .chain_err(|| "error while casting DGPS station ID to u16")?,
+                        )
+                    }
 
-                // Finally the GPX 1.1 extensions
-                "extensions" => extensions::consume(context)?,
-                child => {
-                    bail!(ErrorKind::InvalidChildElement(
-                        String::from(child),
-                        "waypoint"
-                    ));
+                    // Finally the GPX 1.1 extensions
+                    "extensions" => extensions::consume(context)?,
+                    child => {
+                        bail!(ErrorKind::InvalidChildElement(
+                            String::from(child),
+                            "waypoint"
+                        ));
+                    }
                 }
-            },
+            }
             XmlEvent::EndElement { ref name } => {
                 ensure!(
                     name.local_name == tagname,


### PR DESCRIPTION
Found an issue with a `.gpx` file, where the `"cmt"` and the `"desc"` fields for the waypoints were empty. It looks to me that is not a problem to have an empty comment or description. Looking at the spec, it just states that those fields must be strings (https://www.topografix.com/GPX/1/1/#type_wptType) , but there is no specification about if the have to be at least of length > 0.

My approach to fix it has been to modify the `string::consume` function, that accepts and additional bool parameter `allow_empty`. Another way would be to create a different function (`consume_opt` for example), that calls the original `consume` and checks the error. The problem with this approach is that I would need to check for the type of error returned from the `string::consume` function, and only if is the `"no content inside string"` one, return the empty string. 