### PR TITLE
Some optimizations

### DIFF
--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -13,13 +13,11 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
     // get required bounds
     let minlat = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "minlat")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "minlat")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("minlat", "bounds"))?;
     let maxlat = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "maxlat")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "maxlat")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("maxlat", "bounds"))?;
 
     let minlat: f64 = minlat
@@ -33,13 +31,11 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
 
     let minlon = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "minlon")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "minlon")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("minlon", "bounds"))?;
     let maxlon = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "maxlon")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "maxlon")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("maxlon", "bounds"))?;
 
     let minlon: f64 = minlon

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -15,14 +15,12 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
     // get required id and domain attributes
     let id = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "id")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "id")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("id", "email"))?;
 
     let domain = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "domain")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "domain")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("domain", "email"))?;
 
     let email = format!("{id}@{domain}", id = &id.value, domain = &domain.value);

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -58,13 +58,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing gpx event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing gpx event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "metadata" if context.version != GpxVersion::Gpx10 => {
                     gpx.metadata = Some(metadata::consume(context)?);

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -49,8 +49,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
     let attributes = verify_starting_tag(context, "gpx")?;
     let version = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "version")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "version")
         .ok_or(ErrorKind::InvalidElementLacksAttribute("version", "gpx"))?;
     gpx.version = version_string_to_version(&version.value)?;
     context.version = gpx.version;

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -18,8 +18,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
     let attributes = verify_starting_tag(context, "link")?;
     let attr = attributes
         .into_iter()
-        .filter(|attr| attr.name.local_name == "href")
-        .nth(0);
+        .find(|attr| attr.name.local_name == "href");
 
     let attr = attr.ok_or(ErrorKind::InvalidElementLacksAttribute("href", "link"))?;
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -28,13 +28,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing link event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing link event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "text" => link.text = Some(string::consume(context, "text", false)?),
                 "type" => link._type = Some(string::consume(context, "type", false)?),

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -22,13 +22,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing metadata event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing metadata event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
                     metadata.name = Some(string::consume(context, "name", false)?);

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -19,13 +19,16 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing person event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing person event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => person.name = Some(string::consume(context, "name", false)?),
                 "email" => person.email = Some(email::consume(context)?),

--- a/src/parser/route.rs
+++ b/src/parser/route.rs
@@ -20,13 +20,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Route> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing route event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing rotue event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
                     route.name = Some(string::consume(context, "name", false)?);

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -20,13 +20,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing track event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing track event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
                     track.name = Some(string::consume(context, "name", false)?);

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -18,13 +18,16 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing tracksegment event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing tracksegment event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "trkpt" => segment.points.push(waypoint::consume(context, "trkpt")?),
                 child => {

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -31,7 +31,6 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
         ))?;
 
     let latitude: f64 = latitude
-        .clone()
         .value
         .parse()
         .chain_err(|| "error while casting latitude to f64")?;
@@ -46,7 +45,6 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
         ))?;
 
     let longitude: f64 = longitude
-        .clone()
         .value
         .parse()
         .chain_err(|| "error while casting longitude to f64")?;
@@ -56,13 +54,16 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
-                next.clone()
+                match next {
+                    Ok(n) => n,
+                    Err(_) => bail!("error while parsing waypoint event"),
+                }
             } else {
                 break;
             }
         };
 
-        match next_event.chain_err(|| Error::from("error while parsing waypoint event"))? {
+        match next_event {
             XmlEvent::StartElement { ref name, .. } => {
                 match name.local_name.as_ref() {
                     "ele" => {

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -24,8 +24,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
     // get required latitude and longitude
     let latitude = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "lat")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "lat")
         .ok_or(ErrorKind::InvalidElementLacksAttribute(
             "latitude", "waypoint",
         ))?;
@@ -37,8 +36,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 
     let longitude = attributes
         .iter()
-        .filter(|attr| attr.name.local_name == "lon")
-        .nth(0)
+        .find(|attr| attr.name.local_name == "lon")
         .ok_or(ErrorKind::InvalidElementLacksAttribute(
             "longitude",
             "waypoint",


### PR DESCRIPTION
On my dummy benchmark (I parsed fuzzing corpus files) these optimizations improve performance total up to 23%.

There's two good performance increasing optimizations.

1. Remove cloning as much as possible (commit 816531ed67dc6d4b8fb53d1f8a80ca6008e2e57a). This gave up to 17% improvement. I'm not really familiar with `error-chain` so I probably did something silly there.

2.  Replace `.filter(p).nth(0)` with `.find(p)` from iterators (commit af771b8e6043af7d6d087f2581207bfd4c3228cb). This caught me by surprise, but showed up to 9% improvement. This was suggested by Clippy, so kudos to them!