### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ documentation = "https://docs.rs/gpx"
 repository = "https://github.com/georust/gpx"
 
 [dependencies]
-geo-types = "0.4"
-xml-rs = "0.8"
+assert_approx_eq = "1"
 chrono = "0.4"
-error-chain = "0.11.0"
-assert_approx_eq = "1.0.0"
+error-chain = "0.12"
+geo-types = "0.5"
+xml-rs = "0.8"
 
 [dev-dependencies]
-geo = "0.12"
+geo = "0.13"

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -51,16 +51,23 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
         .parse()
         .chain_err(|| "error while casting max longitude to f64")?;
 
-    let bounds: Rect<f64> = Rect {
-        min: Coordinate {
+    // Verify bounding box first, since Rect::new will panic if these are wrong.
+    if minlon > maxlon {
+        bail!("Minimum longitude larger than maximum longitude");
+    } else if minlat > maxlat {
+        bail!("Minimum latitude larger than maximum latitude");
+    }
+
+    let bounds: Rect<f64> = Rect::new(
+        Coordinate {
             x: minlon,
             y: minlat,
         },
-        max: Coordinate {
+        Coordinate {
             x: maxlon,
             y: maxlat,
         },
-    };
+    );
 
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
@@ -102,10 +109,10 @@ mod tests {
         assert!(bounds.is_ok());
 
         let bounds = bounds.unwrap();
-        assert_eq!(bounds.min.x, -74.031837463);
-        assert_eq!(bounds.min.y, 45.487064362);
-        assert_eq!(bounds.max.x, -73.586273193);
-        assert_eq!(bounds.max.y, 45.701225281);
+        assert_eq!(bounds.min().x, -74.031837463);
+        assert_eq!(bounds.min().y, 45.487064362);
+        assert_eq!(bounds.max().x, -73.586273193);
+        assert_eq!(bounds.max().y, 45.701225281);
     }
 
     #[test]

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -53,7 +53,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
 
 #[cfg(test)]
 mod tests {
-    use geo::euclidean_length::EuclideanLength;
+    use geo::algorithm::euclidean_length::EuclideanLength;
     use std::io::BufReader;
 
     use super::consume;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -227,10 +227,10 @@ fn write_bounds_if_exists<W: Write>(
     if let Some(ref bounds) = bounds {
         write_xml_event(
             XmlEvent::start_element("bounds")
-                .attr("minlat", &bounds.min.y.to_string())
-                .attr("maxlat", &bounds.max.y.to_string())
-                .attr("minlon", &bounds.min.x.to_string())
-                .attr("maxlon", &bounds.max.x.to_string()),
+                .attr("minlat", &bounds.min().y.to_string())
+                .attr("maxlat", &bounds.max().y.to_string())
+                .attr("minlon", &bounds.min().x.to_string())
+                .attr("maxlon", &bounds.max().x.to_string()),
             writer,
         )?;
         write_xml_event(XmlEvent::end_element(), writer)?;


### PR DESCRIPTION
geo-types: 0.4 -> 0.5
geo: 0.12 -> 0.13

New version of geo-types includes Rect::new function which will panic if our minimums or maximums are in wrong way.