### PR TITLE
Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "gpx"
 description = "Rust read/write support for GPS Exchange Format (GPX)"
 license = "MIT"
@@ -8,6 +7,7 @@ authors = ["Brendan Ashworth <brendan.ashworth@me.com>", "Corey Farwell <coreyf@
 readme = "README.md"
 documentation = "https://docs.rs/gpx"
 repository = "https://github.com/georust/gpx"
+edition = "2018"
 
 [dependencies]
 assert_approx_eq = "1"

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate gpx;
 extern crate test;
 
 const NITER: usize = 100;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 //! errors provides error generics for the gpx parser.
 
+use error_chain::*;
+
 // This gives us our error boilerplate macros.
 error_chain! {
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,24 +31,10 @@
 //! assert_eq!(segment.points[2].elevation, Some(6.87));
 //! ```
 
-#[macro_use]
-extern crate error_chain;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_approx_eq;
-
-extern crate chrono;
-extern crate geo_types;
-extern crate xml;
-
-#[cfg(test)]
-extern crate geo;
-
 // Export our type structs in the root, along with the read and write functions.
-pub use reader::read;
-pub use types::*;
-pub use writer::write;
+pub use crate::reader::read;
+pub use crate::types::*;
+pub use crate::writer::write;
 
 mod parser;
 mod reader;

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -1,11 +1,12 @@
-use errors::*;
+use crate::errors::*;
 
 use geo_types::{Coordinate, Rect};
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
 /// consume consumes a bounds element until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
@@ -91,7 +92,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_bounds() {

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -1,12 +1,11 @@
-use crate::errors::*;
-
-use geo_types::{Coordinate, Rect};
 use std::io::Read;
-use xml::reader::XmlEvent;
-use error_chain::{bail, ensure};
 
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
+use error_chain::{bail, ensure};
+use geo_types::{Coordinate, Rect};
+use xml::reader::XmlEvent;
+
+use crate::errors::*;
+use crate::parser::{verify_starting_tag, Context};
 
 /// consume consumes a bounds element until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
@@ -69,10 +68,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
     for event in context.reader() {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
-                bail!(ErrorKind::InvalidChildElement(
-                    name.local_name,
-                    "bounds"
-                ));
+                bail!(ErrorKind::InvalidChildElement(name.local_name, "bounds"));
             }
             XmlEvent::EndElement { name } => {
                 ensure!(
@@ -89,8 +85,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -70,14 +70,14 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Rect<f64>> {
         match event.chain_err(|| "error while parsing XML")? {
             XmlEvent::StartElement { name, .. } => {
                 bail!(ErrorKind::InvalidChildElement(
-                    name.local_name.clone(),
+                    name.local_name,
                     "bounds"
                 ));
             }
             XmlEvent::EndElement { name } => {
                 ensure!(
                     name.local_name == "bounds",
-                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "bounds")
+                    ErrorKind::InvalidClosingTag(name.local_name, "bounds")
                 );
                 return Ok(bounds);
             }

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -1,11 +1,12 @@
 //! email handles parsing of GPX-spec emails.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
 /// consume consumes a GPX email from the `reader` until it ends.
 /// When it returns, the reader will be at the element after the end GPX email
@@ -54,7 +55,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_simple_email() {

--- a/src/parser/email.rs
+++ b/src/parser/email.rs
@@ -1,12 +1,12 @@
 //! email handles parsing of GPX-spec emails.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
-use error_chain::{bail, ensure};
 
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
+use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
+
+use crate::errors::*;
+use crate::parser::{verify_starting_tag, Context};
 
 /// consume consumes a GPX email from the `reader` until it ends.
 /// When it returns, the reader will be at the element after the end GPX email
@@ -52,8 +52,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -34,7 +34,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
         }
     }
 
-    return Err("no end tag for extensions".into());
+    Err("no end tag for extensions".into())
 }
 
 #[cfg(test)]

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -2,11 +2,12 @@
 
 // TODO: extensions are not implemented
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
-use error_chain::{bail, ensure};
 
+use error_chain::ensure;
+use xml::reader::XmlEvent;
+
+use crate::errors::*;
 use crate::parser::Context;
 
 /// consume consumes a single string as tag content.
@@ -39,8 +40,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/extensions.rs
+++ b/src/parser/extensions.rs
@@ -2,11 +2,12 @@
 
 // TODO: extensions are not implemented
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::Context;
+use crate::parser::Context;
 
 /// consume consumes a single string as tag content.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<()> {
@@ -41,7 +42,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_arbitrary_extensions() {

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -1,11 +1,9 @@
 //! fix handles parsing of xsd:simpleType "fixType".
 
-use crate::errors::*;
 use std::io::Read;
 
-use crate::parser::string;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{string, Context};
 use crate::types::Fix;
 
 /// consume consumes an element as a fix.
@@ -26,12 +24,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
-
-    use crate::Fix;
-    use crate::GpxVersion;
+    use crate::{Fix, GpxVersion};
 
     #[test]
     fn consume_fix() {

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -21,7 +21,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
         _ => Fix::Other(fix_string),
     };
 
-    return Ok(fix);
+    Ok(fix)
 }
 
 #[cfg(test)]

--- a/src/parser/fix.rs
+++ b/src/parser/fix.rs
@@ -1,12 +1,12 @@
 //! fix handles parsing of xsd:simpleType "fixType".
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 
-use parser::string;
-use parser::Context;
+use crate::parser::string;
+use crate::parser::Context;
 
-use types::Fix;
+use crate::types::Fix;
 
 /// consume consumes an element as a fix.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Fix> {
@@ -30,8 +30,8 @@ mod tests {
 
     use super::consume;
 
-    use Fix;
-    use GpxVersion;
+    use crate::Fix;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_fix() {

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -115,7 +115,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
             XmlEvent::EndElement { name } => {
                 ensure!(
                     name.local_name == "gpx",
-                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "gpx")
+                    ErrorKind::InvalidClosingTag(name.local_name, "gpx")
                 );
                 if gpx.version == GpxVersion::Gpx10 {
                     let mut metadata: Metadata = Default::default();

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -1,27 +1,17 @@
 //! gpx handles parsing of GPX elements.
 
-use chrono::{DateTime, Utc};
-use crate::errors::*;
-use geo_types::Rect;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
+use chrono::{DateTime, Utc};
 use error_chain::{bail, ensure};
+use geo_types::Rect;
+use xml::reader::XmlEvent;
 
-use crate::parser::bounds;
-use crate::parser::metadata;
-use crate::parser::route;
-use crate::parser::string;
-use crate::parser::time;
-use crate::parser::track;
-use crate::parser::verify_starting_tag;
-use crate::parser::waypoint;
-use crate::parser::Context;
-
-use crate::Gpx;
-use crate::GpxVersion;
-use crate::Link;
-use crate::Metadata;
-use crate::Person;
+use crate::errors::*;
+use crate::parser::{
+    bounds, metadata, route, string, time, track, verify_starting_tag, waypoint, Context,
+};
+use crate::{Gpx, GpxVersion, Link, Metadata, Person};
 
 /// Convert the version string to the version enum
 fn version_string_to_version(version_str: &str) -> Result<GpxVersion> {
@@ -115,7 +105,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
             XmlEvent::EndElement { name } => {
                 ensure!(
                     name.local_name == "gpx",
-                    ErrorKind::InvalidClosingTag(name.local_name, "gpx")
+                    ErrorKind::InvalidClosingTag(name.local_name.clone(), "gpx")
                 );
                 if gpx.version == GpxVersion::Gpx10 {
                     let mut metadata: Metadata = Default::default();
@@ -152,7 +142,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
 #[cfg(test)]
 mod tests {
     use geo_types::Point;
-    use std::io::BufReader;
 
     use super::consume;
     use crate::GpxVersion;

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -1,26 +1,27 @@
 //! gpx handles parsing of GPX elements.
 
 use chrono::{DateTime, Utc};
-use errors::*;
+use crate::errors::*;
 use geo_types::Rect;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::bounds;
-use parser::metadata;
-use parser::route;
-use parser::string;
-use parser::time;
-use parser::track;
-use parser::verify_starting_tag;
-use parser::waypoint;
-use parser::Context;
+use crate::parser::bounds;
+use crate::parser::metadata;
+use crate::parser::route;
+use crate::parser::string;
+use crate::parser::time;
+use crate::parser::track;
+use crate::parser::verify_starting_tag;
+use crate::parser::waypoint;
+use crate::parser::Context;
 
-use Gpx;
-use GpxVersion;
-use Link;
-use Metadata;
-use Person;
+use crate::Gpx;
+use crate::GpxVersion;
+use crate::Link;
+use crate::Metadata;
+use crate::Person;
 
 /// Convert the version string to the version enum
 fn version_string_to_version(version_str: &str) -> Result<GpxVersion> {
@@ -154,7 +155,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_gpx() {

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -1,14 +1,12 @@
 //! link handles parsing of GPX-spec links.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::string;
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{string, verify_starting_tag, Context};
 use crate::Link;
 
 /// consume consumes a GPX link from the `reader` until it ends.
@@ -64,8 +62,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Link> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -1,14 +1,15 @@
 //! link handles parsing of GPX-spec links.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::string;
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::string;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
-use Link;
+use crate::Link;
 
 /// consume consumes a GPX link from the `reader` until it ends.
 /// When it returns, the reader will be at the element after the end GPX link
@@ -66,7 +67,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_simple_link() {

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -1,19 +1,20 @@
 //! metadata handles parsing of GPX-spec metadata.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::bounds;
-use parser::extensions;
-use parser::link;
-use parser::person;
-use parser::string;
-use parser::time;
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::bounds;
+use crate::parser::extensions;
+use crate::parser::link;
+use crate::parser::person;
+use crate::parser::string;
+use crate::parser::time;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
-use Metadata;
+use crate::Metadata;
 
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
     let mut metadata: Metadata = Default::default();
@@ -87,7 +88,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_empty() {

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -1,19 +1,12 @@
 //! metadata handles parsing of GPX-spec metadata.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::bounds;
-use crate::parser::extensions;
-use crate::parser::link;
-use crate::parser::person;
-use crate::parser::string;
-use crate::parser::time;
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{bounds, extensions, link, person, string, time, verify_starting_tag, Context};
 use crate::Metadata;
 
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
@@ -84,8 +77,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
 
 #[cfg(test)]
 mod tests {
-    use chrono::prelude::*;
-    use std::io::BufReader;
+    use chrono::{TimeZone, Utc};
 
     use super::consume;
     use crate::GpxVersion;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,7 @@
 #[macro_export]
 macro_rules! consume {
     ($xml:expr, $version:expr) => {{
+        use std::io::BufReader;
         use crate::parser::create_context;
         consume(&mut create_context(
             BufReader::new($xml.as_bytes()),
@@ -12,6 +13,7 @@ macro_rules! consume {
         ))
     }};
     ($xml:expr, $version:expr, $tagname:expr) => {{
+        use std::io::BufReader;
         use crate::parser::create_context;
         consume(
             &mut create_context(BufReader::new($xml.as_bytes()), $version),
@@ -19,6 +21,7 @@ macro_rules! consume {
         )
     }};
     ($xml:expr, $version:expr, $tagname:expr, $allow_empty:expr) => {{
+        use std::io::BufReader;
         use crate::parser::create_context;
         consume(
             &mut create_context(BufReader::new($xml.as_bytes()), $version),
@@ -43,16 +46,16 @@ pub mod track;
 pub mod tracksegment;
 pub mod waypoint;
 
-use crate::errors::*;
 use std::io::Read;
 use std::iter::Peekable;
-use crate::types::GpxVersion;
-use xml::attribute::OwnedAttribute;
-use xml::reader::Events;
-use xml::reader::XmlEvent;
-use xml::EventReader;
-use xml::ParserConfig;
+
 use error_chain::{bail, ensure};
+use xml::attribute::OwnedAttribute;
+use xml::reader::{Events, XmlEvent};
+use xml::{EventReader, ParserConfig};
+
+use crate::errors::*;
+use crate::types::GpxVersion;
 
 pub struct Context<R: Read> {
     reader: Peekable<Events<R>>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,21 +5,21 @@
 #[macro_export]
 macro_rules! consume {
     ($xml:expr, $version:expr) => {{
-        use parser::create_context;
+        use crate::parser::create_context;
         consume(&mut create_context(
             BufReader::new($xml.as_bytes()),
             $version,
         ))
     }};
     ($xml:expr, $version:expr, $tagname:expr) => {{
-        use parser::create_context;
+        use crate::parser::create_context;
         consume(
             &mut create_context(BufReader::new($xml.as_bytes()), $version),
             $tagname,
         )
     }};
     ($xml:expr, $version:expr, $tagname:expr, $allow_empty:expr) => {{
-        use parser::create_context;
+        use crate::parser::create_context;
         consume(
             &mut create_context(BufReader::new($xml.as_bytes()), $version),
             $tagname,
@@ -43,15 +43,16 @@ pub mod track;
 pub mod tracksegment;
 pub mod waypoint;
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use std::iter::Peekable;
-use types::GpxVersion;
+use crate::types::GpxVersion;
 use xml::attribute::OwnedAttribute;
 use xml::reader::Events;
 use xml::reader::XmlEvent;
 use xml::EventReader;
 use xml::ParserConfig;
+use error_chain::{bail, ensure};
 
 pub struct Context<R: Read> {
     reader: Peekable<Events<R>>,

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -1,16 +1,12 @@
 //! person handles parsing of GPX-spec persons.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::email;
-use crate::parser::link;
-use crate::parser::string;
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{email, link, string, verify_starting_tag, Context};
 use crate::Person;
 
 pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<Person> {
@@ -60,8 +56,6 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/person.rs
+++ b/src/parser/person.rs
@@ -1,16 +1,17 @@
 //! person handles parsing of GPX-spec persons.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::email;
-use parser::link;
-use parser::string;
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::email;
+use crate::parser::link;
+use crate::parser::string;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
-use Person;
+use crate::Person;
 
 pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<Person> {
     let mut person: Person = Default::default();
@@ -62,7 +63,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_whole_person() {

--- a/src/parser/route.rs
+++ b/src/parser/route.rs
@@ -1,16 +1,12 @@
 //! route handles parsing of GPX-spec routes.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::link;
-use crate::parser::string;
-use crate::parser::verify_starting_tag;
-use crate::parser::waypoint;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{link, string, verify_starting_tag, waypoint, Context};
 use crate::Route;
 
 /// consume consumes a GPX route from the `reader` until it ends.
@@ -76,8 +72,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Route> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/route.rs
+++ b/src/parser/route.rs
@@ -1,16 +1,17 @@
 //! route handles parsing of GPX-spec routes.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::link;
-use parser::string;
-use parser::verify_starting_tag;
-use parser::waypoint;
-use parser::Context;
+use crate::parser::link;
+use crate::parser::string;
+use crate::parser::verify_starting_tag;
+use crate::parser::waypoint;
+use crate::parser::Context;
 
-use Route;
+use crate::Route;
 
 /// consume consumes a GPX route from the `reader` until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Route> {
@@ -78,7 +79,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_full_route() {

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -1,12 +1,12 @@
 //! string handles parsing of GPX-spec strings.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
-use error_chain::{bail, ensure};
 
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
+use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
+
+use crate::errors::*;
+use crate::parser::{verify_starting_tag, Context};
 
 /// consume consumes a single string as tag content.
 pub fn consume<R: Read>(
@@ -44,8 +44,6 @@ pub fn consume<R: Read>(
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -1,11 +1,12 @@
 //! string handles parsing of GPX-spec strings.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
 /// consume consumes a single string as tag content.
 pub fn consume<R: Read>(
@@ -46,7 +47,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_simple_string() {

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -1,14 +1,14 @@
 //! time handles parsing of xsd:dateTime.
 
 /// format: [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 
 use chrono::prelude::Utc;
 use chrono::DateTime;
 
-use parser::string;
-use parser::Context;
+use crate::parser::string;
+use crate::parser::Context;
 
 /// consume consumes an element as a time.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
@@ -25,7 +25,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_time() {

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -1,14 +1,13 @@
 //! time handles parsing of xsd:dateTime.
 
 /// format: [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-use crate::errors::*;
 use std::io::Read;
 
 use chrono::prelude::Utc;
 use chrono::DateTime;
 
-use crate::parser::string;
-use crate::parser::Context;
+use crate::errors::*;
+use crate::parser::{string, Context};
 
 /// consume consumes an element as a time.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
@@ -22,8 +21,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -17,7 +17,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<DateTime<Utc>> {
     let time =
         DateTime::parse_from_rfc3339(&time).chain_err(|| "error while parsing time as RFC3339")?;
 
-    return Ok(DateTime::from_utc(time.naive_utc(), Utc));
+    Ok(DateTime::from_utc(time.naive_utc(), Utc))
 }
 
 #[cfg(test)]

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -1,16 +1,12 @@
 //! track handles parsing of GPX-spec tracks.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::link;
-use crate::parser::string;
-use crate::parser::tracksegment;
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{link, string, tracksegment, verify_starting_tag, Context};
 use crate::Track;
 
 /// consume consumes a GPX track from the `reader` until it ends.
@@ -76,8 +72,6 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::BufReader;
-
     use super::consume;
     use crate::GpxVersion;
 

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -1,16 +1,17 @@
 //! track handles parsing of GPX-spec tracks.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::link;
-use parser::string;
-use parser::tracksegment;
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::link;
+use crate::parser::string;
+use crate::parser::tracksegment;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
-use Track;
+use crate::Track;
 
 /// consume consumes a GPX track from the `reader` until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Track> {
@@ -78,7 +79,7 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_full_track() {

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -1,14 +1,15 @@
 //! tracksegment handles parsing of GPX-spec track segments.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
-use parser::verify_starting_tag;
-use parser::waypoint;
-use parser::Context;
+use crate::parser::verify_starting_tag;
+use crate::parser::waypoint;
+use crate::parser::Context;
 
-use TrackSegment;
+use crate::TrackSegment;
 
 /// consume consumes a GPX track segment from the `reader` until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
@@ -58,9 +59,10 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
 mod tests {
     use geo::algorithm::euclidean_length::EuclideanLength;
     use std::io::BufReader;
+    use assert_approx_eq::assert_approx_eq;
 
     use super::consume;
-    use GpxVersion;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_full_trkseg() {

--- a/src/parser/tracksegment.rs
+++ b/src/parser/tracksegment.rs
@@ -1,14 +1,12 @@
 //! tracksegment handles parsing of GPX-spec track segments.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
+use xml::reader::XmlEvent;
 
-use crate::parser::verify_starting_tag;
-use crate::parser::waypoint;
-use crate::parser::Context;
-
+use crate::errors::*;
+use crate::parser::{verify_starting_tag, waypoint, Context};
 use crate::TrackSegment;
 
 /// consume consumes a GPX track segment from the `reader` until it ends.
@@ -57,9 +55,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<TrackSegment> {
 
 #[cfg(test)]
 mod tests {
-    use geo::algorithm::euclidean_length::EuclideanLength;
-    use std::io::BufReader;
     use assert_approx_eq::assert_approx_eq;
+    use geo::euclidean_length::EuclideanLength;
 
     use super::consume;
     use crate::GpxVersion;

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -1,21 +1,14 @@
 //! waypoint handles parsing of GPX-spec waypoints.
 
-use crate::errors::*;
 use std::io::Read;
-use xml::reader::XmlEvent;
+
 use error_chain::{bail, ensure};
-
 use geo_types::Point;
-use crate::parser::extensions;
-use crate::parser::fix;
-use crate::parser::link;
-use crate::parser::string;
-use crate::parser::time;
-use crate::parser::verify_starting_tag;
-use crate::parser::Context;
+use xml::reader::XmlEvent;
 
-use crate::Waypoint;
-use crate::GpxVersion;
+use crate::errors::*;
+use crate::parser::{extensions, fix, link, string, time, verify_starting_tag, Context};
+use crate::{GpxVersion, Waypoint};
 
 /// consume consumes a GPX waypoint from the `reader` until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<Waypoint> {
@@ -170,11 +163,9 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
 #[cfg(test)]
 mod tests {
     use geo_types::Point;
-    use std::io::BufReader;
 
     use super::consume;
-    use crate::Fix;
-    use crate::GpxVersion;
+    use crate::{Fix, GpxVersion};
 
     #[test]
     fn consume_waypoint() {

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -1,21 +1,21 @@
 //! waypoint handles parsing of GPX-spec waypoints.
 
-use errors::*;
+use crate::errors::*;
 use std::io::Read;
 use xml::reader::XmlEvent;
+use error_chain::{bail, ensure};
 
 use geo_types::Point;
-use parser::extensions;
-use parser::fix;
-use parser::link;
-use parser::string;
-use parser::time;
-use parser::verify_starting_tag;
-use parser::Context;
+use crate::parser::extensions;
+use crate::parser::fix;
+use crate::parser::link;
+use crate::parser::string;
+use crate::parser::time;
+use crate::parser::verify_starting_tag;
+use crate::parser::Context;
 
-use Waypoint;
-
-use GpxVersion;
+use crate::Waypoint;
+use crate::GpxVersion;
 
 /// consume consumes a GPX waypoint from the `reader` until it ends.
 pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Result<Waypoint> {
@@ -173,8 +173,8 @@ mod tests {
     use std::io::BufReader;
 
     use super::consume;
-    use Fix;
-    use GpxVersion;
+    use crate::Fix;
+    use crate::GpxVersion;
 
     #[test]
     fn consume_waypoint() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,11 +2,11 @@
 
 use std::io::Read;
 
-use errors::*;
+use crate::errors::*;
 
-use parser::{create_context, gpx};
-use Gpx;
-use GpxVersion;
+use crate::parser::{create_context, gpx};
+use crate::Gpx;
+use crate::GpxVersion;
 
 /// Reads an activity in GPX format.
 ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,10 +3,8 @@
 use std::io::Read;
 
 use crate::errors::*;
-
 use crate::parser::{create_context, gpx};
-use crate::Gpx;
-use crate::GpxVersion;
+use crate::{Gpx, GpxVersion};
 
 /// Reads an activity in GPX format.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,8 +2,7 @@
 
 use geo_types::{Geometry, LineString, MultiLineString, Point, Rect};
 
-use chrono::prelude::Utc;
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GpxVersion {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,15 +4,16 @@ use std::io::Write;
 
 use chrono::prelude::Utc;
 use chrono::DateTime;
+use error_chain::bail;
 
 use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 
 use geo_types::Rect;
 
-use errors::*;
-use types::*;
-use Gpx;
-use GpxVersion;
+use crate::errors::*;
+use crate::types::*;
+use crate::Gpx;
+use crate::GpxVersion;
 
 /// Writes an activity to GPX format.
 ///

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,18 +2,14 @@
 
 use std::io::Write;
 
-use chrono::prelude::Utc;
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use error_chain::bail;
-
-use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
-
 use geo_types::Rect;
+use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 
 use crate::errors::*;
 use crate::types::*;
-use crate::Gpx;
-use crate::GpxVersion;
+use crate::{Gpx, GpxVersion};
 
 /// Writes an activity to GPX format.
 ///

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -156,7 +156,7 @@ fn write_email_if_exists<W: Write>(
     writer: &mut EventWriter<W>,
 ) -> Result<()> {
     if let Some(ref email) = email {
-        let mut parts = email.split("@");
+        let mut parts = email.split('@');
         let id = parts.next().ok_or("Missing id part in email!")?;
         let domain = parts.next().ok_or("Missing domain part in email!")?;
         if parts.next().is_some() {

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -2,288 +2,285 @@
 // Feel free to read through these tests and their accompanying
 // .gpx files to see how usage might be.
 
-#[cfg(test)]
-mod tests {
-    use chrono::prelude::*;
-    use geo::algorithm::haversine_distance::HaversineDistance;
-    use geo::euclidean_length::EuclideanLength;
-    use geo_types::{Geometry, Point};
-    use std::fs::File;
-    use std::io::BufReader;
-    use assert_approx_eq::assert_approx_eq;
+use std::fs::File;
+use std::io::BufReader;
 
-    use gpx::read;
-    use gpx::Fix;
+use assert_approx_eq::assert_approx_eq;
+use chrono::{TimeZone, Utc};
+use geo::algorithm::haversine_distance::HaversineDistance;
+use geo::euclidean_length::EuclideanLength;
+use geo_types::{Geometry, Point};
 
-    #[test]
-    fn gpx_reader_read_test_badxml() {
-        // Should fail with badly formatted XML.
-        let file = File::open("tests/fixtures/badcharacter.xml").unwrap();
-        let reader = BufReader::new(file);
+use gpx::{read, Fix};
 
-        let result = read(reader);
+#[test]
+fn gpx_reader_read_test_badxml() {
+    // Should fail with badly formatted XML.
+    let file = File::open("tests/fixtures/badcharacter.xml").unwrap();
+    let reader = BufReader::new(file);
 
-        assert!(result.is_err());
-    }
+    let result = read(reader);
 
-    #[test]
-    fn gpx_reader_read_test_wikipedia() {
-        // Should not give an error, and should have all the correct data.
-        let file = File::open("tests/fixtures/wikipedia_example.gpx").unwrap();
-        let reader = BufReader::new(file);
+    assert!(result.is_err());
+}
 
-        let result = read(reader);
-        assert!(result.is_ok());
+#[test]
+fn gpx_reader_read_test_wikipedia() {
+    // Should not give an error, and should have all the correct data.
+    let file = File::open("tests/fixtures/wikipedia_example.gpx").unwrap();
+    let reader = BufReader::new(file);
 
-        let result = result.unwrap();
+    let result = read(reader);
+    assert!(result.is_ok());
 
-        // Check the metadata, of course; here it has a time.
-        let metadata = result.metadata.unwrap();
-        assert_eq!(
-            metadata.time.unwrap(),
-            Utc.ymd(2009, 10, 17).and_hms(22, 58, 43)
-        );
+    let result = result.unwrap();
 
-        assert_eq!(metadata.links.len(), 1);
-        let link = &metadata.links[0];
-        assert_eq!(link.href, "http://www.garmin.com");
-        assert_eq!(link.text, Some(String::from("Garmin International")));
+    // Check the metadata, of course; here it has a time.
+    let metadata = result.metadata.unwrap();
+    assert_eq!(
+        metadata.time.unwrap(),
+        Utc.ymd(2009, 10, 17).and_hms(22, 58, 43)
+    );
 
-        // There should just be one track, "example gpx document".
-        assert_eq!(result.tracks.len(), 1);
-        let track = &result.tracks[0];
+    assert_eq!(metadata.links.len(), 1);
+    let link = &metadata.links[0];
+    assert_eq!(link.href, "http://www.garmin.com");
+    assert_eq!(link.text, Some(String::from("Garmin International")));
 
-        assert_eq!(track.name, Some(String::from("Example GPX Document")));
+    // There should just be one track, "example gpx document".
+    assert_eq!(result.tracks.len(), 1);
+    let track = &result.tracks[0];
 
-        // Each point has its own information; test elevation.
-        assert_eq!(track.segments.len(), 1);
-        let points = &track.segments[0].points;
+    assert_eq!(track.name, Some(String::from("Example GPX Document")));
 
-        assert_eq!(points.len(), 3);
-        assert_eq!(points[0].elevation, Some(4.46));
-        assert_eq!(points[1].elevation, Some(4.94));
-        assert_eq!(points[2].elevation, Some(6.87));
-    }
+    // Each point has its own information; test elevation.
+    assert_eq!(track.segments.len(), 1);
+    let points = &track.segments[0].points;
 
-    #[test]
-    fn gpx_reader_read_test_gpsies() {
-        // Should not give an error, and should have all the correct data.
-        let file = File::open("tests/fixtures/gpsies_example.gpx").unwrap();
-        let reader = BufReader::new(file);
+    assert_eq!(points.len(), 3);
+    assert_eq!(points[0].elevation, Some(4.46));
+    assert_eq!(points[1].elevation, Some(4.94));
+    assert_eq!(points[2].elevation, Some(6.87));
+}
 
-        let result = read(reader);
-        match result {
-            Ok(_) => {}
-            Err(ref e) => {
-                println!("{:?}", e);
-            }
-        }
-        assert!(result.is_ok());
+#[test]
+fn gpx_reader_read_test_gpsies() {
+    // Should not give an error, and should have all the correct data.
+    let file = File::open("tests/fixtures/gpsies_example.gpx").unwrap();
+    let reader = BufReader::new(file);
 
-        let result = result.unwrap();
-
-        // Check the metadata, of course; here it has a time.
-        let metadata = result.metadata.unwrap();
-        assert_eq!(
-            metadata.time.unwrap(),
-            Utc.ymd(2019, 09, 11).and_hms(17, 08, 31)
-        );
-
-        assert_eq!(metadata.links.len(), 1);
-        let link = &metadata.links[0];
-        assert_eq!(link.href, "https://www.gpsies.com/");
-        assert_eq!(link.text, Some(String::from("Innrunde on AllTrails")));
-
-        // There should just be one track, "example gpx document".
-        assert_eq!(result.tracks.len(), 1);
-        let track = &result.tracks[0];
-
-        assert_eq!(track.name, Some(String::from("Innrunde on AllTrails")));
-
-        let link = &result.tracks[0].links[0];
-
-        assert_eq!(link.href, "https://www.gpsies.com/map.do");
-
-        // Each point has its own information; test elevation.
-        assert_eq!(track.segments.len(), 1);
-        let points = &track.segments[0].points;
-
-        assert_eq!(points[0].elevation, Some(305.0));
-        assert_eq!(points[1].elevation, Some(304.0));
-        assert_eq!(points[2].elevation, Some(305.0));
-    }
-
-    #[test]
-    fn gpx_reader_read_test_garmin_activity() {
-        let file = File::open("tests/fixtures/garmin-activity.gpx").unwrap();
-        let reader = BufReader::new(file);
-
-        let result = read(reader);
-        assert!(result.is_ok());
-        let res = result.unwrap();
-
-        // Check the info on the metadata.
-        let metadata = res.metadata.unwrap();
-        assert_eq!(
-            metadata.time.unwrap(),
-            Utc.ymd(2017, 7, 29).and_hms_micro(14, 46, 35, 000_000)
-        );
-
-        assert_eq!(metadata.links.len(), 1);
-        let link = &metadata.links[0];
-        assert_eq!(link.text, Some(String::from("Garmin Connect")));
-        assert_eq!(link.href, String::from("connect.garmin.com"));
-
-        // Check the main track.
-        assert_eq!(res.tracks.len(), 1);
-        let track = &res.tracks[0];
-
-        assert_eq!(track.name, Some(String::from("casual stroll")));
-        assert_eq!(track._type, Some(String::from("running")));
-
-        // Check some Geo operations on the track.
-        let mls = track.multilinestring();
-        assert_approx_eq!(mls.euclidean_length(), 0.12704048);
-
-        // Get the first track segment.
-        assert_eq!(track.segments.len(), 1);
-        let segment = &track.segments[0];
-
-        // Test for every single point in the file.
-        for point in segment.points.iter() {
-            // Elevation is between 90 and 220.
-            let elevation = point.elevation.unwrap();
-            assert!(elevation > 90. && elevation < 220.);
-
-            // All the points should be close (5000 units, its closer than you think).
-            let reference_point = Point::new(-121.97, 37.24);
-            let distance = reference_point.haversine_distance(&point.point());
-            assert!(distance < 5000.);
-
-            // Time is between a day before and after.
-            let time = point.time.unwrap();
-            assert!(time > Utc.ymd(2017, 7, 28).and_hms_micro(0, 0, 0, 000_000));
-            assert!(time < Utc.ymd(2017, 7, 30).and_hms_micro(0, 0, 0, 000_000));
-
-            // Should coerce to Point.
-            let geo: Geometry<f64> = point.clone().into();
-            match geo {
-                Geometry::Point(_) => {} // ok
-                _ => panic!("point.into() gave bad geometry"),
-            }
-
-            // It's missing almost all fields, actually.
-            assert!(point.name.is_none());
-            assert!(point.comment.is_none());
-            assert!(point.description.is_none());
-            assert!(point.source.is_none());
-            assert!(point.symbol.is_none());
-            assert!(point._type.is_none());
-            assert_eq!(point.links.len(), 0);
+    let result = read(reader);
+    match result {
+        Ok(_) => {}
+        Err(ref e) => {
+            println!("{:?}", e);
         }
     }
+    assert!(result.is_ok());
 
-    #[test]
-    fn gpx_reader_read_test_lovers_lane() {
-        let file = File::open("tests/fixtures/ecology-trail-and-lovers-lane-loop.gpx").unwrap();
-        let reader = BufReader::new(file);
+    let result = result.unwrap();
 
-        let result = read(reader);
-        assert!(result.is_ok());
-        let res = result.unwrap();
+    // Check the metadata, of course; here it has a time.
+    let metadata = result.metadata.unwrap();
+    assert_eq!(
+        metadata.time.unwrap(),
+        Utc.ymd(2019, 09, 11).and_hms(17, 08, 31)
+    );
 
-        // Check the info on the metadata.
-        let metadata = res.metadata.unwrap();
+    assert_eq!(metadata.links.len(), 1);
+    let link = &metadata.links[0];
+    assert_eq!(link.href, "https://www.gpsies.com/");
+    assert_eq!(link.text, Some(String::from("Innrunde on AllTrails")));
 
-        assert_eq!(metadata.name, Some(String::from("Trail Planner Map")));
-        assert_eq!(metadata.links.len(), 1);
-        let link = &metadata.links[0];
-        assert_eq!(
-            link.text,
-            Some(String::from("Trail Planner Map on AllTrails"))
-        );
-        assert_eq!(link.href, String::from("https://www.gpsies.com/"));
+    // There should just be one track, "example gpx document".
+    assert_eq!(result.tracks.len(), 1);
+    let track = &result.tracks[0];
 
-        // Check the main track.
-        let route = &res.route;
-        assert_eq!(
-            route.name,
-            Some(String::from("Trail Planner Map on AllTrails"))
-        );
-        assert_eq!(route.points.len(), 139);
+    assert_eq!(track.name, Some(String::from("Innrunde on AllTrails")));
 
-        // Test for every single point in the file.
-        for point in route.points.iter() {
-            // Elevation is between 15 and 100
-            let elevation = point.elevation.unwrap();
-            assert!(elevation > 15. && elevation < 100.);
+    let link = &result.tracks[0].links[0];
 
-            // Should coerce to Point.
-            let geo: Geometry<f64> = point.clone().into();
-            match geo {
-                Geometry::Point(_) => {} // ok
-                _ => panic!("point.into() gave bad geometry"),
-            }
+    assert_eq!(link.href, "https://www.gpsies.com/map.do");
 
-            // It's missing almost all fields, actually.
-            assert!(point.name.is_none());
-            assert!(point.comment.is_none());
-            assert!(point.description.is_none());
-            assert!(point.source.is_none());
-            assert!(point.symbol.is_none());
-            assert!(point._type.is_none());
-            assert_eq!(point.links.len(), 0);
+    // Each point has its own information; test elevation.
+    assert_eq!(track.segments.len(), 1);
+    let points = &track.segments[0].points;
+
+    assert_eq!(points[0].elevation, Some(305.0));
+    assert_eq!(points[1].elevation, Some(304.0));
+    assert_eq!(points[2].elevation, Some(305.0));
+}
+
+#[test]
+fn gpx_reader_read_test_garmin_activity() {
+    let file = File::open("tests/fixtures/garmin-activity.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    assert!(result.is_ok());
+    let res = result.unwrap();
+
+    // Check the info on the metadata.
+    let metadata = res.metadata.unwrap();
+    assert_eq!(
+        metadata.time.unwrap(),
+        Utc.ymd(2017, 7, 29).and_hms_micro(14, 46, 35, 000_000)
+    );
+
+    assert_eq!(metadata.links.len(), 1);
+    let link = &metadata.links[0];
+    assert_eq!(link.text, Some(String::from("Garmin Connect")));
+    assert_eq!(link.href, String::from("connect.garmin.com"));
+
+    // Check the main track.
+    assert_eq!(res.tracks.len(), 1);
+    let track = &res.tracks[0];
+
+    assert_eq!(track.name, Some(String::from("casual stroll")));
+    assert_eq!(track._type, Some(String::from("running")));
+
+    // Check some Geo operations on the track.
+    let mls = track.multilinestring();
+    assert_approx_eq!(mls.euclidean_length(), 0.12704048);
+
+    // Get the first track segment.
+    assert_eq!(track.segments.len(), 1);
+    let segment = &track.segments[0];
+
+    // Test for every single point in the file.
+    for point in segment.points.iter() {
+        // Elevation is between 90 and 220.
+        let elevation = point.elevation.unwrap();
+        assert!(elevation > 90. && elevation < 220.);
+
+        // All the points should be close (5000 units, its closer than you think).
+        let reference_point = Point::new(-121.97, 37.24);
+        let distance = reference_point.haversine_distance(&point.point());
+        assert!(distance < 5000.);
+
+        // Time is between a day before and after.
+        let time = point.time.unwrap();
+        assert!(time > Utc.ymd(2017, 7, 28).and_hms_micro(0, 0, 0, 000_000));
+        assert!(time < Utc.ymd(2017, 7, 30).and_hms_micro(0, 0, 0, 000_000));
+
+        // Should coerce to Point.
+        let geo: Geometry<f64> = point.clone().into();
+        match geo {
+            Geometry::Point(_) => {} // ok
+            _ => panic!("point.into() gave bad geometry"),
         }
+
+        // It's missing almost all fields, actually.
+        assert!(point.name.is_none());
+        assert!(point.comment.is_none());
+        assert!(point.description.is_none());
+        assert!(point.source.is_none());
+        assert!(point.symbol.is_none());
+        assert!(point._type.is_none());
+        assert_eq!(point.links.len(), 0);
     }
+}
 
-    #[test]
-    fn gpx_reader_read_test_with_accuracy() {
-        let file = File::open("tests/fixtures/with_accuracy.gpx").unwrap();
-        let reader = BufReader::new(file);
+#[test]
+fn gpx_reader_read_test_lovers_lane() {
+    let file = File::open("tests/fixtures/ecology-trail-and-lovers-lane-loop.gpx").unwrap();
+    let reader = BufReader::new(file);
 
-        let result = read(reader);
-        assert!(result.is_ok());
-        let res = result.unwrap();
+    let result = read(reader);
+    assert!(result.is_ok());
+    let res = result.unwrap();
 
-        // Check the info on the metadata.
-        let metadata = res.metadata.unwrap();
-        assert_eq!(metadata.name.unwrap(), "20170412_CARDIO.gpx");
+    // Check the info on the metadata.
+    let metadata = res.metadata.unwrap();
 
-        assert_eq!(metadata.links.len(), 0);
+    assert_eq!(metadata.name, Some(String::from("Trail Planner Map")));
+    assert_eq!(metadata.links.len(), 1);
+    let link = &metadata.links[0];
+    assert_eq!(
+        link.text,
+        Some(String::from("Trail Planner Map on AllTrails"))
+    );
+    assert_eq!(link.href, String::from("https://www.gpsies.com/"));
 
-        // Check the main track.
-        assert_eq!(res.tracks.len(), 1);
-        let track = &res.tracks[0];
+    // Check the main track.
+    let route = &res.route;
+    assert_eq!(
+        route.name,
+        Some(String::from("Trail Planner Map on AllTrails"))
+    );
+    assert_eq!(route.points.len(), 139);
 
-        assert_eq!(track.name, Some(String::from("Cycling")));
+    // Test for every single point in the file.
+    for point in route.points.iter() {
+        // Elevation is between 15 and 100
+        let elevation = point.elevation.unwrap();
+        assert!(elevation > 15. && elevation < 100.);
 
-        // Get the first track segment.
-        assert_eq!(track.segments.len(), 1);
-        let segment = &track.segments[0];
+        // Should coerce to Point.
+        let geo: Geometry<f64> = point.clone().into();
+        match geo {
+            Geometry::Point(_) => {} // ok
+            _ => panic!("point.into() gave bad geometry"),
+        }
 
-        // Get the first point
-        assert_eq!(segment.points.len(), 3);
-        let points = &segment.points;
-
-        assert_eq!(points[0].fix, Some(Fix::DGPS));
-        assert_eq!(points[0].sat.unwrap(), 4);
-        assert_eq!(points[0].hdop.unwrap(), 5.);
-        assert_eq!(points[0].vdop.unwrap(), 6.2);
-        assert_eq!(points[0].pdop.unwrap(), 728.);
-        assert_eq!(points[0].age.unwrap(), 1.);
-        assert_eq!(points[0].dgpsid.unwrap(), 3);
-
-        assert_eq!(points[1].fix, Some(Fix::ThreeDimensional));
-        assert_eq!(points[1].sat.unwrap(), 5);
-        assert_eq!(points[1].hdop.unwrap(), 3.6);
-        assert_eq!(points[1].vdop.unwrap(), 5.);
-        assert_eq!(points[1].pdop.unwrap(), 619.1);
-        assert_eq!(points[1].age.unwrap(), 2.01);
-        assert_eq!(points[1].dgpsid.unwrap(), 4);
-
-        assert_eq!(
-            points[2].fix,
-            Some(Fix::Other("something_not_in_the_spec".to_string()))
-        );
+        // It's missing almost all fields, actually.
+        assert!(point.name.is_none());
+        assert!(point.comment.is_none());
+        assert!(point.description.is_none());
+        assert!(point.source.is_none());
+        assert!(point.symbol.is_none());
+        assert!(point._type.is_none());
+        assert_eq!(point.links.len(), 0);
     }
+}
+
+#[test]
+fn gpx_reader_read_test_with_accuracy() {
+    let file = File::open("tests/fixtures/with_accuracy.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    assert!(result.is_ok());
+    let res = result.unwrap();
+
+    // Check the info on the metadata.
+    let metadata = res.metadata.unwrap();
+    assert_eq!(metadata.name.unwrap(), "20170412_CARDIO.gpx");
+
+    assert_eq!(metadata.links.len(), 0);
+
+    // Check the main track.
+    assert_eq!(res.tracks.len(), 1);
+    let track = &res.tracks[0];
+
+    assert_eq!(track.name, Some(String::from("Cycling")));
+
+    // Get the first track segment.
+    assert_eq!(track.segments.len(), 1);
+    let segment = &track.segments[0];
+
+    // Get the first point
+    assert_eq!(segment.points.len(), 3);
+    let points = &segment.points;
+
+    assert_eq!(points[0].fix, Some(Fix::DGPS));
+    assert_eq!(points[0].sat.unwrap(), 4);
+    assert_eq!(points[0].hdop.unwrap(), 5.);
+    assert_eq!(points[0].vdop.unwrap(), 6.2);
+    assert_eq!(points[0].pdop.unwrap(), 728.);
+    assert_eq!(points[0].age.unwrap(), 1.);
+    assert_eq!(points[0].dgpsid.unwrap(), 3);
+
+    assert_eq!(points[1].fix, Some(Fix::ThreeDimensional));
+    assert_eq!(points[1].sat.unwrap(), 5);
+    assert_eq!(points[1].hdop.unwrap(), 3.6);
+    assert_eq!(points[1].vdop.unwrap(), 5.);
+    assert_eq!(points[1].pdop.unwrap(), 619.1);
+    assert_eq!(points[1].age.unwrap(), 2.01);
+    assert_eq!(points[1].dgpsid.unwrap(), 4);
+
+    assert_eq!(
+        points[2].fix,
+        Some(Fix::Other("something_not_in_the_spec".to_string()))
+    );
 }

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -2,14 +2,6 @@
 // Feel free to read through these tests and their accompanying
 // .gpx files to see how usage might be.
 
-#[macro_use]
-extern crate assert_approx_eq;
-
-extern crate chrono;
-extern crate geo;
-extern crate geo_types;
-extern crate gpx;
-
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
@@ -18,6 +10,7 @@ mod tests {
     use geo_types::{Geometry, Point};
     use std::fs::File;
     use std::io::BufReader;
+    use assert_approx_eq::assert_approx_eq;
 
     use gpx::read;
     use gpx::Fix;

--- a/tests/gpx_write.rs
+++ b/tests/gpx_write.rs
@@ -1,124 +1,118 @@
-#[cfg(test)]
-mod tests {
-    use std::fs::File;
-    use std::io::BufReader;
+use std::fs::File;
+use std::io::BufReader;
 
-    use gpx::read;
-    use gpx::write;
-    use gpx::Gpx;
-    use gpx::Link;
-    use gpx::Waypoint;
+use gpx::{read, write};
+use gpx::{Gpx, Link, Waypoint};
 
-    #[test]
-    fn gpx_writer_write_unknown_gpx_version() {
-        let gpx: Gpx = Default::default();
-        let mut writer: Vec<u8> = Vec::new();
-        // Should fail with unknown version.
-        let result = write(&gpx, &mut writer);
+#[test]
+fn gpx_writer_write_unknown_gpx_version() {
+    let gpx: Gpx = Default::default();
+    let mut writer: Vec<u8> = Vec::new();
+    // Should fail with unknown version.
+    let result = write(&gpx, &mut writer);
 
-        assert!(result.is_err());
+    assert!(result.is_err());
+}
+
+#[test]
+fn gpx_writer_write_test_wikipedia() {
+    check_write_for_example_file("tests/fixtures/wikipedia_example.gpx");
+}
+
+#[test]
+fn gpx_writer_write_test_garmin_activity() {
+    check_write_for_example_file("tests/fixtures/garmin-activity.gpx");
+}
+
+#[test]
+fn gpx_writer_write_test_with_accuracy() {
+    check_write_for_example_file("tests/fixtures/with_accuracy.gpx");
+}
+
+fn check_write_for_example_file(filename: &str) {
+    let reference_gpx = read_test_gpx_file(filename);
+    let written_gpx = write_and_reread_gpx(&reference_gpx);
+
+    check_metadata_equal(&reference_gpx, &written_gpx);
+    check_points_equal(&reference_gpx, &written_gpx);
+}
+
+fn read_test_gpx_file(filename: &str) -> Gpx {
+    let file = File::open(filename).unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    assert!(result.is_ok());
+
+    result.unwrap()
+}
+
+fn write_and_reread_gpx(reference_gpx: &Gpx) -> Gpx {
+    let mut buffer: Vec<u8> = Vec::new();
+    let result = write(&reference_gpx, &mut buffer);
+    assert!(result.is_ok());
+
+    let written_gpx = read(buffer.as_slice()).unwrap();
+    written_gpx
+}
+
+fn check_metadata_equal(reference_gpx: &Gpx, written_gpx: &Gpx) {
+    let reference = &reference_gpx.metadata;
+    let written = &written_gpx.metadata;
+    if reference.is_some() {
+        assert!(written.is_some());
+    } else {
+        assert!(written.is_none());
+        return;
     }
+    let reference = reference.as_ref().unwrap();
+    let written = written.as_ref().unwrap();
+    assert_eq!(reference.name, written.name);
+    assert_eq!(reference.time, written.time);
+    check_links_equal(&reference.links, &written.links);
+}
 
-    #[test]
-    fn gpx_writer_write_test_wikipedia() {
-        check_write_for_example_file("tests/fixtures/wikipedia_example.gpx");
+fn check_links_equal(reference: &Vec<Link>, written: &Vec<Link>) {
+    assert_eq!(reference.len(), written.len());
+    for (r, w) in reference.iter().zip(written) {
+        assert_eq!(r.href, w.href);
+        assert_eq!(r.text, w.text);
     }
+}
 
-    #[test]
-    fn gpx_writer_write_test_garmin_activity() {
-        check_write_for_example_file("tests/fixtures/garmin-activity.gpx");
-    }
-
-    #[test]
-    fn gpx_writer_write_test_with_accuracy() {
-        check_write_for_example_file("tests/fixtures/with_accuracy.gpx");
-    }
-
-    fn check_write_for_example_file(filename: &str) {
-        let reference_gpx = read_test_gpx_file(filename);
-        let written_gpx = write_and_reread_gpx(&reference_gpx);
-
-        check_metadata_equal(&reference_gpx, &written_gpx);
-        check_points_equal(&reference_gpx, &written_gpx);
-    }
-
-    fn read_test_gpx_file(filename: &str) -> Gpx {
-        let file = File::open(filename).unwrap();
-        let reader = BufReader::new(file);
-
-        let result = read(reader);
-        assert!(result.is_ok());
-
-        result.unwrap()
-    }
-
-    fn write_and_reread_gpx(reference_gpx: &Gpx) -> Gpx {
-        let mut buffer: Vec<u8> = Vec::new();
-        let result = write(&reference_gpx, &mut buffer);
-        assert!(result.is_ok());
-
-        let written_gpx = read(buffer.as_slice()).unwrap();
-        written_gpx
-    }
-
-    fn check_metadata_equal(reference_gpx: &Gpx, written_gpx: &Gpx) {
-        let reference = &reference_gpx.metadata;
-        let written = &written_gpx.metadata;
-        if reference.is_some() {
-            assert!(written.is_some());
-        } else {
-            assert!(written.is_none());
-            return;
-        }
-        let reference = reference.as_ref().unwrap();
-        let written = written.as_ref().unwrap();
-        assert_eq!(reference.name, written.name);
-        assert_eq!(reference.time, written.time);
-        check_links_equal(&reference.links, &written.links);
-    }
-
-    fn check_links_equal(reference: &Vec<Link>, written: &Vec<Link>) {
-        assert_eq!(reference.len(), written.len());
-        for (r, w) in reference.iter().zip(written) {
-            assert_eq!(r.href, w.href);
-            assert_eq!(r.text, w.text);
-        }
-    }
-
-    fn check_points_equal(reference: &Gpx, written: &Gpx) {
-        check_waypoints_equal(&reference.waypoints, &written.waypoints);
-        assert_eq!(reference.tracks.len(), written.tracks.len());
-        for (r_track, w_track) in reference.tracks.iter().zip(written.tracks.iter()) {
-            assert_eq!(r_track.name, w_track.name);
-            assert_eq!(r_track.segments.len(), w_track.segments.len());
-            for (r_seg, w_seg) in r_track.segments.iter().zip(w_track.segments.iter()) {
-                check_waypoints_equal(&r_seg.points, &w_seg.points);
-            }
+fn check_points_equal(reference: &Gpx, written: &Gpx) {
+    check_waypoints_equal(&reference.waypoints, &written.waypoints);
+    assert_eq!(reference.tracks.len(), written.tracks.len());
+    for (r_track, w_track) in reference.tracks.iter().zip(written.tracks.iter()) {
+        assert_eq!(r_track.name, w_track.name);
+        assert_eq!(r_track.segments.len(), w_track.segments.len());
+        for (r_seg, w_seg) in r_track.segments.iter().zip(w_track.segments.iter()) {
+            check_waypoints_equal(&r_seg.points, &w_seg.points);
         }
     }
+}
 
-    fn check_waypoints_equal(reference: &Vec<Waypoint>, written: &Vec<Waypoint>) {
-        assert_eq!(reference.len(), written.len());
-        for (r_wp, w_wp) in reference.iter().zip(written) {
-            assert_eq!(r_wp.point(), w_wp.point());
-            assert_eq!(r_wp.elevation, w_wp.elevation);
-            assert_eq!(r_wp.speed, w_wp.speed);
-            assert_eq!(r_wp.time, w_wp.time);
-            assert_eq!(r_wp.geoidheight, w_wp.geoidheight);
-            assert_eq!(r_wp.name, w_wp.name);
-            assert_eq!(r_wp.comment, w_wp.comment);
-            assert_eq!(r_wp.description, w_wp.description);
-            assert_eq!(r_wp.source, w_wp.source);
-            check_links_equal(&r_wp.links, &w_wp.links);
-            assert_eq!(r_wp.symbol, w_wp.symbol);
-            assert_eq!(r_wp._type, w_wp._type);
-            assert_eq!(r_wp.fix, w_wp.fix);
-            assert_eq!(r_wp.sat, w_wp.sat);
-            assert_eq!(r_wp.hdop, w_wp.hdop);
-            assert_eq!(r_wp.vdop, w_wp.vdop);
-            assert_eq!(r_wp.pdop, w_wp.pdop);
-            assert_eq!(r_wp.age, w_wp.age);
-            assert_eq!(r_wp.dgpsid, w_wp.dgpsid);
-        }
+fn check_waypoints_equal(reference: &Vec<Waypoint>, written: &Vec<Waypoint>) {
+    assert_eq!(reference.len(), written.len());
+    for (r_wp, w_wp) in reference.iter().zip(written) {
+        assert_eq!(r_wp.point(), w_wp.point());
+        assert_eq!(r_wp.elevation, w_wp.elevation);
+        assert_eq!(r_wp.speed, w_wp.speed);
+        assert_eq!(r_wp.time, w_wp.time);
+        assert_eq!(r_wp.geoidheight, w_wp.geoidheight);
+        assert_eq!(r_wp.name, w_wp.name);
+        assert_eq!(r_wp.comment, w_wp.comment);
+        assert_eq!(r_wp.description, w_wp.description);
+        assert_eq!(r_wp.source, w_wp.source);
+        check_links_equal(&r_wp.links, &w_wp.links);
+        assert_eq!(r_wp.symbol, w_wp.symbol);
+        assert_eq!(r_wp._type, w_wp._type);
+        assert_eq!(r_wp.fix, w_wp.fix);
+        assert_eq!(r_wp.sat, w_wp.sat);
+        assert_eq!(r_wp.hdop, w_wp.hdop);
+        assert_eq!(r_wp.vdop, w_wp.vdop);
+        assert_eq!(r_wp.pdop, w_wp.pdop);
+        assert_eq!(r_wp.age, w_wp.age);
+        assert_eq!(r_wp.dgpsid, w_wp.dgpsid);
     }
 }

--- a/tests/gpx_write.rs
+++ b/tests/gpx_write.rs
@@ -1,7 +1,3 @@
-extern crate geo;
-extern crate geo_types;
-extern crate gpx;
-
 #[cfg(test)]
 mod tests {
     use std::fs::File;


### PR DESCRIPTION
Convert crate to Rust 2018 edition. While there fix all the Clippy nags and cleanup `use` statements, etc. and `rustfmt` the code.