### PR TITLE
Add support for having multiple routes in GPX

### DIFF
--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -66,7 +66,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                     gpx.tracks.push(track::consume(context)?);
                 }
                 "rte" => {
-                    gpx.route = route::consume(context)?;
+                    gpx.routes.push(route::consume(context)?);
                 }
                 "wpt" => {
                     gpx.waypoints.push(waypoint::consume(context, "wpt")?);

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,8 +32,8 @@ pub struct Gpx {
     /// A list of tracks.
     pub tracks: Vec<Track>,
 
-    /// A route with a list of point-by-point directions
-    pub route: Route,
+    /// A list of routes with a list of point-by-point directions
+    pub routes: Vec<Route>,
 }
 
 /// Metadata is information about the GPX file, author, and copyright restrictions.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -44,7 +44,9 @@ pub fn write<W: Write>(gpx: &Gpx, writer: W) -> Result<()> {
     for track in &gpx.tracks {
         write_track(track, &mut writer)?;
     }
-    write_route(&gpx.route, &mut writer)?;
+    for route in &gpx.routes {
+            write_route(route, &mut writer)?;
+    }
     write_xml_event(XmlEvent::end_element(), &mut writer)?;
     Ok(())
 }

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -203,15 +203,15 @@ fn gpx_reader_read_test_lovers_lane() {
     assert_eq!(link.href, String::from("https://www.gpsies.com/"));
 
     // Check the main track.
-    let route = &res.route;
+    let routes = &res.routes;
     assert_eq!(
-        route.name,
+        routes[0].name,
         Some(String::from("Trail Planner Map on AllTrails"))
     );
-    assert_eq!(route.points.len(), 139);
+    assert_eq!(routes[0].points.len(), 139);
 
     // Test for every single point in the file.
-    for point in route.points.iter() {
+    for point in routes[0].points.iter() {
         // Elevation is between 15 and 100
         let elevation = point.elevation.unwrap();
         assert!(elevation > 15. && elevation < 100.);


### PR DESCRIPTION
According to both GPX specifications 1.0 and 1.1, GPX file can have zero or more routes defined. This makes routes `Vec` like waypoints and tracks.

Fixes #34