### PR TITLE
Rename "ageofgpsdata" field to "ageofdgpsdata"

### DIFF
--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -118,11 +118,11 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> Resu
                                 "error while casting position dilution of precision (pdop) to f64"
                             })?,
                     ),
-                    "ageofgpsdata" => {
-                        waypoint.age = Some(
-                            string::consume(context, "ageofgpsdata", false)?
+                    "ageofdgpsdata" => {
+                        waypoint.dgps_age = Some(
+                            string::consume(context, "ageofdgpsdata", false)?
                                 .parse()
-                                .chain_err(|| "error while casting age of GPS data to f64")?,
+                                .chain_err(|| "error while casting age of DGPS data to f64")?,
                         )
                     }
                     "dgpsid" => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -317,8 +317,11 @@ pub struct Waypoint {
     /// Positional dilution of precision.
     pub pdop: Option<f64>,
 
-    /// Number of seconds since last DGPS update, from the <ageofgpsdata> element.
+    #[deprecated = "Prior to gpx 0.9.0 version crate used incorrect field to parse and emit DGPS age. Use `dgps_age` instead. See https://github.com/georust/gpx/issues/21"]
     pub age: Option<f64>,
+
+    /// Number of seconds since last DGPS update, from the <ageofdgpsdata> element.
+    pub dgps_age: Option<f64>,
 
     /// ID of DGPS station used in differential correction, in the range [0, 1023].
     pub dgpsid: Option<u16>,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -327,7 +327,7 @@ fn write_waypoint<W: Write>(
     write_value_if_exists("hdop", &waypoint.hdop, writer)?;
     write_value_if_exists("vdop", &waypoint.vdop, writer)?;
     write_value_if_exists("pdop", &waypoint.pdop, writer)?;
-    write_value_if_exists("ageofgpsdata", &waypoint.age, writer)?;
+    write_value_if_exists("ageofdgpsdata", &waypoint.dgps_age, writer)?;
     write_value_if_exists("dgpsid", &waypoint.dgpsid, writer)?;
     write_xml_event(XmlEvent::end_element(), writer)?;
     Ok(())

--- a/tests/fixtures/with_accuracy.gpx
+++ b/tests/fixtures/with_accuracy.gpx
@@ -17,7 +17,7 @@
                 <hdop>5</hdop>
                 <vdop>6.2</vdop>
                 <pdop>728</pdop>
-                <ageofgpsdata>1</ageofgpsdata>
+                <ageofdgpsdata>1</ageofdgpsdata>
                 <dgpsid>3</dgpsid>
             </trkpt>
             <trkpt lat="51.120654" lon="3.772442">
@@ -28,7 +28,7 @@
                 <hdop>3.6</hdop>
                 <vdop>5</vdop>
                 <pdop>619.1</pdop>
-                <ageofgpsdata>2.01</ageofgpsdata>
+                <ageofdgpsdata>2.01</ageofdgpsdata>
                 <dgpsid>4</dgpsid>
             </trkpt>
             <trkpt lat="51.130122" lon="3.773967">

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -268,7 +268,7 @@ fn gpx_reader_read_test_with_accuracy() {
     assert_eq!(points[0].hdop.unwrap(), 5.);
     assert_eq!(points[0].vdop.unwrap(), 6.2);
     assert_eq!(points[0].pdop.unwrap(), 728.);
-    assert_eq!(points[0].age.unwrap(), 1.);
+    assert_eq!(points[0].dgps_age.unwrap(), 1.);
     assert_eq!(points[0].dgpsid.unwrap(), 3);
 
     assert_eq!(points[1].fix, Some(Fix::ThreeDimensional));
@@ -276,7 +276,7 @@ fn gpx_reader_read_test_with_accuracy() {
     assert_eq!(points[1].hdop.unwrap(), 3.6);
     assert_eq!(points[1].vdop.unwrap(), 5.);
     assert_eq!(points[1].pdop.unwrap(), 619.1);
-    assert_eq!(points[1].age.unwrap(), 2.01);
+    assert_eq!(points[1].dgps_age.unwrap(), 2.01);
     assert_eq!(points[1].dgpsid.unwrap(), 4);
 
     assert_eq!(

--- a/tests/gpx_write.rs
+++ b/tests/gpx_write.rs
@@ -112,7 +112,7 @@ fn check_waypoints_equal(reference: &Vec<Waypoint>, written: &Vec<Waypoint>) {
         assert_eq!(r_wp.hdop, w_wp.hdop);
         assert_eq!(r_wp.vdop, w_wp.vdop);
         assert_eq!(r_wp.pdop, w_wp.pdop);
-        assert_eq!(r_wp.age, w_wp.age);
+        assert_eq!(r_wp.dgps_age, w_wp.dgps_age);
         assert_eq!(r_wp.dgpsid, w_wp.dgpsid);
     }
 }


### PR DESCRIPTION
While there, change the Waypoint's age member to dgps_age to be more descriptive what it does.

I took the liberty to fix the [tests/fixtures/with_accuracy.gpx](https://github.com/georust/gpx/blob/master/tests/fixtures/with_accuracy.gpx) file to conform to specification and to fix the tests.

Fixes #21