### PR TITLE
Add support for reading and writing of the GPX creator attribute

### DIFF
--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -45,6 +45,11 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
     gpx.version = version_string_to_version(&version.value)?;
     context.version = gpx.version;
 
+    let creator = attributes
+        .iter()
+        .find(|attr| attr.name.local_name == "creator");
+    gpx.creator = creator.map(|c| c.value.to_owned());
+
     loop {
         let next_event = {
             if let Some(next) = context.reader.peek() {
@@ -169,6 +174,14 @@ mod tests {
         let gpx = consume!("<gpx version=\"1.2\"></gpx>", GpxVersion::Unknown);
 
         assert!(gpx.is_err());
+    }
+
+    #[test]
+    fn consume_gpx_creator() {
+        let gpx = consume!("<gpx version=\"1.1\" creator=\"unit test\"></gpx>", GpxVersion::Unknown);
+
+        assert!(gpx.is_ok());
+        assert_eq!(gpx.unwrap().creator, Some("unit test".into()));
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,6 +23,9 @@ pub struct Gpx {
     /// Version of the Gpx file.
     pub version: GpxVersion,
 
+    /// Creator name or URL of the software that created GPX document
+    pub creator: Option<String>,
+
     /// Metadata about the file.
     pub metadata: Option<Metadata>,
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -31,10 +31,11 @@ pub fn write<W: Write>(gpx: &Gpx, writer: W) -> Result<()> {
     let mut writer = EmitterConfig::new()
         .perform_indent(true)
         .create_writer(writer);
+    let creator: &str = gpx.creator.as_deref().unwrap_or("https://github.com/georust/gpx");
     write_xml_event(
         XmlEvent::start_element("gpx")
             .attr("version", version_to_version_string(gpx.version)?)
-            .attr("creator", "https://github.com/georust/gpx"),
+            .attr("creator", creator),
         &mut writer,
     )?;
     write_metadata(gpx, &mut writer)?;


### PR DESCRIPTION
The intent in GPX 1.1 specification is to

> include the name or URL of the software that created your GPX document. This allows others to inform the creator of a GPX instance document that fails to validate.

However, it is also used by some software to identify a device. For example by Strava (https://developers.strava.com/docs/uploads/):

> Device type is detected in all file types from standard ‘creator’ tags. These tags are then matched to a list of known devices. In some cases the name of the device will be displayed along with the activity details.

Fixes #40