### PR TITLE
Use XML tag "desc" instead of "description"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [#49](https://github.com/georust/gpx/pull/49): Use correct XML tag "desc" instead of "description"
+
 ## 0.8.1
 
 - [allow empty fields: "desc", "cmt", "description", "keywords", "src"](https://github.com/georust/gpx/pull/25)

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -97,8 +97,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx> {
                 "name" if context.version == GpxVersion::Gpx10 => {
                     gpx_name = Some(string::consume(context, "name", false)?);
                 }
-                "description" if context.version == GpxVersion::Gpx10 => {
-                    description = Some(string::consume(context, "description", true)?);
+                "desc" if context.version == GpxVersion::Gpx10 => {
+                    description = Some(string::consume(context, "desc", true)?);
                 }
                 "keywords" if context.version == GpxVersion::Gpx10 => {
                     keywords = Some(string::consume(context, "keywords", true)?);

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -30,8 +30,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Metadata> {
                 "name" => {
                     metadata.name = Some(string::consume(context, "name", false)?);
                 }
-                "description" => {
-                    metadata.description = Some(string::consume(context, "description", true)?);
+                "desc" => {
+                    metadata.description = Some(string::consume(context, "desc", true)?);
                 }
                 "author" => {
                     metadata.author = Some(person::consume(context, "author")?);
@@ -103,7 +103,7 @@ mod tests {
             <metadata>
                 <link href=\"example.com\" />
                 <name>xxname</name>
-                <description>xxdescription</description>
+                <desc>xxdescription</desc>
                 <author>
                     <name>John Doe</name>
                     <email id=\"john.doe\" domain=\"example.com\" />

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -87,7 +87,7 @@ fn write_gpx10_metadata<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>) -> Res
     }
     let metadata = gpx.metadata.as_ref().unwrap();
     write_string_if_exists("name", &metadata.name, writer)?;
-    write_string_if_exists("description", &metadata.description, writer)?;
+    write_string_if_exists("desc", &metadata.description, writer)?;
     if let Some(author) = metadata.author.as_ref() {
         write_string_if_exists("author", &author.name, writer)?;
         write_email_if_exists(&author.email, writer)?;
@@ -109,7 +109,7 @@ fn write_gpx11_metadata<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>) -> Res
     let metadata = gpx.metadata.as_ref().unwrap();
     write_xml_event(XmlEvent::start_element("metadata"), writer)?;
     write_string_if_exists("name", &metadata.name, writer)?;
-    write_string_if_exists("description", &metadata.description, writer)?;
+    write_string_if_exists("desc", &metadata.description, writer)?;
     write_person_if_exists("author", &metadata.author, writer)?;
     write_string_if_exists("keywords", &metadata.keywords, writer)?;
     write_time_if_exists(&metadata.time, writer)?;


### PR DESCRIPTION
The description field of the metadata type is parsed and written with the "description" tag instead of "desc." I believe this is an error, as all other description fields in the crate follow the schema correctly for this field. This pull request resolves that discrepancy and should fix #48.

Schema reference: [1.0](https://www.topografix.com/gpx_manual.asp#desc)/[1.1](https://www.topografix.com/GPX/1/1/#type_metadataType)