### PR TITLE
Release version 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## 0.8.2
 
 - [#49](https://github.com/georust/gpx/pull/49): Use correct XML tag "desc" instead of "description"
 - [#48](https://github.com/georust/gpx/pull/48): Support parsing copyright tag in metadata

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gpx"
 description = "Rust read/write support for GPS Exchange Format (GPX)"
 license = "MIT"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Brendan Ashworth <brendan.ashworth@me.com>", "Corey Farwell <coreyf@rwell.org>", "Felix Gruber <felgru@gmx.de>"]
 readme = "README.md"
 documentation = "https://docs.rs/gpx"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

