### PR TITLE
Allow customize xml::writer::EventWriter in write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [#61](https://github.com/georust/gpx/pull/61): Allow custom xml::EventWriter in write(add `write_with_event_writer`)
+
 ## 0.8.4
 
 - [#57](https://github.com/georust/gpx/pull/57): Support Number on Tracks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 // Export our type structs in the root, along with the read and write functions.
 pub use crate::reader::read;
 pub use crate::types::*;
-pub use crate::writer::write;
+pub use crate::writer::{write, write_with_event_writer};
 
 mod parser;
 mod reader;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---
Fix #60 
