### PR TITLE
Do not crash if a gpx file has an extensions tag in its route tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+
+- [#66](https://github.com/georust/gpx/pull/66): Allow `extensions` tags inside of `route`
+
 ## 0.8.5
 
 - [#61](https://github.com/georust/gpx/pull/61): Allow custom xml::EventWriter in write(add `write_with_event_writer`)

--- a/src/parser/route.rs
+++ b/src/parser/route.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use xml::reader::XmlEvent;
 
 use crate::errors::{GpxError, GpxResult};
-use crate::parser::{link, string, verify_starting_tag, waypoint, Context};
+use crate::parser::{extensions, link, string, verify_starting_tag, waypoint, Context};
 use crate::Route;
 
 /// consume consumes a GPX route from the `reader` until it ends.
@@ -50,6 +50,9 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Route> {
                 }
                 "link" => {
                     route.links.push(link::consume(context)?);
+                }
+                "extensions" => {
+                    extensions::consume(context)?;
                 }
                 child => {
                     return Err(GpxError::InvalidChildElement(String::from(child), "route"));

--- a/tests/fixtures/viking_with_route_extensions.gpx
+++ b/tests/fixtures/viking_with_route_extensions.gpx
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<gpx version="1.1"
+creator="Viking 1.10 -- http://viking.sf.net/"
+xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:wptx1="http://www.garmin.com/xmlschemas/WaypointExtension/v1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxpx="http://www.garmin.com/xmlschemas/PowerExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/WaypointExtension/v1 http://www8.garmin.com/xmlschemas/WaypointExtensionv1.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 http://www.garmin.com/xmlschemas/TrackPointExtensionv2.xsd http://www.garmin.com/xmlschemas/PowerExtensionv1.xsd">
+<wpt lat="40.71488" lon="-74.011422">
+  <name>001</name>
+</wpt>
+<trk>
+  <name>Trace</name>
+  <extensions><gpxx:TrackExtension><gpxx:DisplayColor>DarkGray</gpxx:DisplayColor></gpxx:TrackExtension></extensions>
+  <trkseg>
+  <trkpt lat="40.71631157206666" lon="-74.01103529632569">
+  </trkpt>
+  <trkpt lat="40.7154983764096" lon="-74.00927576721192">
+  </trkpt>
+  <trkpt lat="40.71435988580241" lon="-74.01021990478516">
+  </trkpt>
+  <trkpt lat="40.7139370129041" lon="-74.00888952911377">
+  </trkpt>
+  <trkpt lat="40.71149730912246" lon="-74.01047739685059">
+  </trkpt>
+  </trkseg>
+</trk>
+<rte>
+  <name>Route</name>
+  <extensions><gpxx:TrackExtension><gpxx:DisplayColor>Red</gpxx:DisplayColor></gpxx:TrackExtension></extensions>
+</rte>
+</gpx>

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -410,3 +410,29 @@ fn garmin_with_extensions() {
     assert_eq!(points.len(), 35);
     assert_eq!(points[0].elevation, Some(860.0));
 }
+
+#[test]
+fn viking_with_route_extensions() {
+    // Should not give an error, and should have all the correct data.
+    let file = File::open("tests/fixtures/viking_with_route_extensions.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    println!("result= {:#?}", result);
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+
+    // There should just be one track, "example gpx document".
+    assert_eq!(result.tracks.len(), 1);
+    let track = &result.tracks[0];
+
+    assert_eq!(track.name, Some(String::from("Trace")));
+
+    // Each point has its own information; test elevation.
+    assert_eq!(track.segments.len(), 1);
+    let points = &track.segments[0].points;
+
+    assert_eq!(points.len(), 5);
+    assert_eq!(points[0].point().lat(), 40.71631157206666);
+}


### PR DESCRIPTION
The extensions tag is also allowed in the route tag (see https://www.topografix.com/GPX/1/1/#type_rteType).

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.


