### PR TITLE
Add `xmlns` attribute in written gpx for better garmin compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#65](https://github.com/georust/gpx/pull/65): Replace `chrono` to `time` crate
 - [#66](https://github.com/georust/gpx/pull/66): Allow `extensions` tags inside of `route`
+- [#67](https://github.com/georust/gpx/pull/67): Add `xmlns` attribute in written gpx for better garmin compatibility
 
 ## 0.8.5
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -64,6 +64,7 @@ pub fn write_with_event_writer<W: Write>(gpx: &Gpx, writer: &mut EventWriter<W>)
     write_xml_event(
         XmlEvent::start_element("gpx")
             .attr("version", version_to_version_string(gpx.version)?)
+            .attr("xmlns", version_to_xml_url(gpx.version)?)
             .attr("creator", creator),
         writer,
     )?;
@@ -93,6 +94,14 @@ fn version_to_version_string(version: GpxVersion) -> GpxResult<&'static str> {
     match version {
         GpxVersion::Gpx10 => Ok("1.0"),
         GpxVersion::Gpx11 => Ok("1.1"),
+        version => Err(GpxError::UnknownVersionError(version)),
+    }
+}
+
+fn version_to_xml_url(version: GpxVersion) -> GpxResult<&'static str> {
+    match version {
+        GpxVersion::Gpx10 => Ok("http://www.topografix.com/GPX/1/0"),
+        GpxVersion::Gpx11 => Ok("http://www.topografix.com/GPX/1/1"),
         version => Err(GpxError::UnknownVersionError(version)),
     }
 }


### PR DESCRIPTION
I noted that the exported GPX files are not accepted by Garmin software (for example Basecamp), and found out this is due to a missing namespace declaration. This PR adds the necessary `xmlns` tag to the `gpx` element.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

