### PR TITLE
Waypoint name can be an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#67](https://github.com/georust/gpx/pull/67): Add `xmlns` attribute in written gpx for better garmin compatibility
 - [#73](https://github.com/georust/gpx/pull/68): Bump CI minimum rust version to 1.56, max to 1.59
 - [#74](https://github.com/georust/gpx/pull/74): Address deprecation warnings from geo-types
+- [#71](https://github.com/georust/gpx/pull/71): Allow empty waypoint names
 
 ## 0.8.5
 

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -203,6 +203,24 @@ mod tests {
     }
 
     #[test]
+    fn consume_empty_waypoint_name() {
+        let waypoint = consume!(
+            "<trkpt lat=\"2.345\" lon=\"1.234\">
+                <name><![CDATA[]]></name>
+            </trkpt>",
+            GpxVersion::Gpx11,
+            "trkpt"
+        );
+
+        assert!(waypoint.is_ok());
+        let waypoint = waypoint.unwrap();
+
+        assert_eq!(waypoint.point(), Point::new(1.234, 2.345));
+        assert_eq!(waypoint.point().lng(), 1.234);
+        assert_eq!(waypoint.point().lat(), 2.345);
+    }
+
+    #[test]
     fn consume_bad_waypoint() {
         let waypoint = consume!(
             "<wpt lat=\"32.4\" lon=\"notanumber\"></wpt>",

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -75,7 +75,7 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> GpxR
                         waypoint.speed = Some(string::consume(context, "speed", false)?.parse()?);
                     }
                     "time" => waypoint.time = Some(time::consume(context)?),
-                    "name" => waypoint.name = Some(string::consume(context, "name", false)?),
+                    "name" => waypoint.name = Some(string::consume(context, "name", true)?),
                     "cmt" => waypoint.comment = Some(string::consume(context, "cmt", true)?),
                     "desc" => waypoint.description = Some(string::consume(context, "desc", true)?),
                     "src" => waypoint.source = Some(string::consume(context, "src", true)?),


### PR DESCRIPTION
Fixes #70


