### PR TITLE
Allow empty elevation tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#73](https://github.com/georust/gpx/pull/68): Bump CI minimum rust version to 1.56, max to 1.59
 - [#74](https://github.com/georust/gpx/pull/74): Address deprecation warnings from geo-types
 - [#71](https://github.com/georust/gpx/pull/71): Allow empty waypoint names
+- [#72](https://github.com/georust/gpx/pull/72): Allow empty elevation tags
 
 ## 0.8.5
 

--- a/src/parser/string.rs
+++ b/src/parser/string.rs
@@ -86,11 +86,25 @@ mod tests {
     }
 
     #[test]
-    fn consume_no_body() {
+    fn consume_no_body_with_err() {
         // must have string content
         let result = consume!("<foo></foo>", GpxVersion::Gpx11, "foo", false);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn consume_no_body_via_complete_tag() {
+        let result = consume!("<foo></foo>", GpxVersion::Gpx11, "foo", true);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn consume_no_body_via_self_closing_tag() {
+        let result = consume!("<foo/>", GpxVersion::Gpx11, "foo", true);
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -68,12 +68,10 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> GpxR
                 match name.local_name.as_ref() {
                     "ele" => {
                         // Cast the elevation to an f64, from a string.
-                        // empty elevation tags will be parsed as 0.00
-                        waypoint.elevation = Some(
-                            string::consume(context, "ele", true)?
-                                .parse()
-                                .unwrap_or_default(),
-                        )
+                        waypoint.elevation = match string::consume(context, "ele", false) {
+                            Ok(v) => Some(v.parse()?),
+                            Err(_) => None,
+                        }
                     }
                     "speed" if context.version == GpxVersion::Gpx10 => {
                         // Speed is from GPX 1.0

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -68,7 +68,12 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> GpxR
                 match name.local_name.as_ref() {
                     "ele" => {
                         // Cast the elevation to an f64, from a string.
-                        waypoint.elevation = Some(string::consume(context, "ele", false)?.parse()?)
+                        // empty elevation tags will be parsed as 0.00
+                        waypoint.elevation = Some(
+                            string::consume(context, "ele", true)?
+                                .parse()
+                                .unwrap_or_default(),
+                        )
                     }
                     "speed" if context.version == GpxVersion::Gpx10 => {
                         // Speed is from GPX 1.0

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -70,7 +70,8 @@ pub fn consume<R: Read>(context: &mut Context<R>, tagname: &'static str) -> GpxR
                         // Cast the elevation to an f64, from a string.
                         waypoint.elevation = match string::consume(context, "ele", false) {
                             Ok(v) => Some(v.parse()?),
-                            Err(_) => None,
+                            Err(GpxError::NoStringContent) => None,
+                            Err(other_err) => return Err(other_err),
                         }
                     }
                     "speed" if context.version == GpxVersion::Gpx10 => {

--- a/tests/fixtures/wahoo_example.gpx
+++ b/tests/fixtures/wahoo_example.gpx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="http://ridewithgps.com/">
+  <metadata>
+    <name>04/24/22</name>
+    <link href="https://ridewithgps.com/trips/1">
+      <text>04/24/22</text>
+    </link>
+    <time>2022-04-24T13:54:33Z</time>
+  </metadata>
+  <trk>
+    <name>04/24/22</name>
+    <trkseg>
+      <trkpt lat="45.454350" lon="-121.933136">
+        <ele/>
+        <time>2022-04-24T20:54:33Z</time>
+      </trkpt>
+      <trkpt lat="45.454350" lon="-121.933136">
+        <ele/>
+        <time>2022-04-24T20:54:34Z</time>
+      </trkpt>
+      <trkpt lat="45.454350" lon="-121.933136">
+        <ele/>
+        <time>2022-04-24T20:54:35Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -135,9 +135,8 @@ fn gpx_reader_read_test_empty_elevation() {
     for track in &res.tracks {
         for segment in &track.segments {
             for point in &segment.points {
-                // Elevation should default to 0.00
-                let elevation = point.elevation.unwrap();
-                assert!(elevation == 0.00);
+                let elevation = point.elevation.is_none();
+                assert_eq!(elevation, true);
             }
         }
     }

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -123,6 +123,27 @@ fn gpx_reader_read_test_gpsies() {
 }
 
 #[test]
+fn gpx_reader_read_test_empty_elevation() {
+    let file = File::open("tests/fixtures/wahoo_example.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    assert!(result.is_ok());
+    let res = result.unwrap();
+
+    // Test for every single point in the file.
+    for track in &res.tracks {
+        for segment in &track.segments {
+            for point in &segment.points {
+                // Elevation should default to 0.00
+                let elevation = point.elevation.unwrap();
+                assert!(elevation == 0.00);
+            }
+        }
+    }
+}
+
+#[test]
 fn gpx_reader_read_test_garmin_activity() {
     let file = File::open("tests/fixtures/garmin-activity.gpx").unwrap();
     let reader = BufReader::new(file);


### PR DESCRIPTION
Similar to https://github.com/georust/gpx/issues/70, I have a GPX file that has self-closing `elevation` tags, which of course, contain no value. This appears to be valid per the GPX spec at https://www.topografix.com/GPX/1/1/#type_ptType.

The GPX file was generated by a Wahoo bike computer.

This change edits the parsing logic to use a default `f64` value of `0.00` for these cases. I didn't see a precedence for handling similar optional values in this lib, so let me know if I should handle this differently in accordance with the project's goals. 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

