### PR TITLE
Address deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#68](https://github.com/georust/gpx/pull/68): Bump CI minimum rust version to 1.53, max to 1.59
 - [#67](https://github.com/georust/gpx/pull/67): Add `xmlns` attribute in written gpx for better garmin compatibility
 - [#73](https://github.com/georust/gpx/pull/68): Bump CI minimum rust version to 1.56, max to 1.59
+- [#74](https://github.com/georust/gpx/pull/74): Address deprecation warnings from geo-types
 
 ## 0.8.5
 

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -198,8 +198,8 @@ mod tests {
         let waypoint = waypoint.unwrap();
 
         assert_eq!(waypoint.point(), Point::new(1.234, 2.345));
-        assert_eq!(waypoint.point().lng(), 1.234);
-        assert_eq!(waypoint.point().lat(), 2.345);
+        assert_eq!(waypoint.point().x(), 1.234);
+        assert_eq!(waypoint.point().y(), 2.345);
     }
 
     #[test]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -347,8 +347,8 @@ fn write_waypoint<W: Write>(
 ) -> GpxResult<()> {
     write_xml_event(
         XmlEvent::start_element(tagname)
-            .attr("lat", &waypoint.point().lat().to_string())
-            .attr("lon", &waypoint.point().lng().to_string()),
+            .attr("lat", &waypoint.point().y().to_string())
+            .attr("lon", &waypoint.point().x().to_string()),
         writer,
     )?;
     write_value_if_exists("ele", &waypoint.elevation, writer)?;

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -488,5 +488,5 @@ fn viking_with_route_extensions() {
     let points = &track.segments[0].points;
 
     assert_eq!(points.len(), 5);
-    assert_eq!(points[0].point().lat(), 40.71631157206666);
+    assert_eq!(points[0].point().y(), 40.71631157206666);
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

