### PR TITLE
Switch from RFC3339 to ISO8601 for timestamp encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.9.0
 
-- [#78](https://github.com/georust/gpx/pull/78): Replace RFC3339 by ISO8601 for de-/encoding time stamps
+- [#78](https://github.com/georust/gpx/pull/78): Replace RFC 3339 by ISO 8601 for de-/encoding time stamps,
+                                                 fix error handling bug on track parsing,
+                                                 apply Clippy suggestion
 
 ## 0.8.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.9.0
+
+- [#78](https://github.com/georust/gpx/pull/78): Replace RFC3339 by ISO8601 for de-/encoding time stamps
+
 ## 0.8.6
 
 - [#65](https://github.com/georust/gpx/pull/65): Replace `chrono` to `time` crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gpx"
 description = "Rust read/write support for GPS Exchange Format (GPX)"
 license = "MIT"
-version = "0.8.6"
+version = "0.9.0"
 authors = ["The GeoRust Developers <mods@georust.org>"]
 readme = "README.md"
 documentation = "https://docs.rs/gpx"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,8 +47,8 @@ pub enum GpxError {
     MetadataParsingError(),
     #[error("invalid `{0}`: must be between `{1}`. Actual value: `{2}`")]
     LonLatOutOfBoundsError(&'static str, &'static str, f64),
-    #[error("error trying to parse RFC3339 formatted date")]
-    Rfc3339Error(#[from] time::error::Parse),
-    #[error("error trying to write RFC3339 formatted date")]
-    Rfc3339ErrorWriting(#[from] time::error::Format),
+    #[error("error trying to parse ISO8601 formatted date")]
+    Iso8601Error(#[from] time::error::Parse),
+    #[error("error trying to write ISO8601 formatted date")]
+    Iso8601ErrorWriting(#[from] time::error::Format),
 }

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -110,24 +110,31 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> Result<Gpx, GpxError> {
                     return Err(GpxError::InvalidClosingTag(name.local_name.clone(), "gpx"));
                 }
                 if gpx.version == GpxVersion::Gpx10 {
-                    let mut metadata: Metadata = Default::default();
-                    metadata.name = gpx_name;
-                    metadata.time = time;
-                    metadata.bounds = bounds;
-                    let mut person: Person = Default::default();
-                    person.name = author;
-                    if let Some(url) = url {
-                        let mut link: Link = Default::default();
-                        link.href = url;
-                        link.text = urlname;
-                        person.link = Some(link);
-                    }
-                    person.email = email;
-                    if person != Default::default() {
-                        metadata.author = Some(person);
-                    }
-                    metadata.keywords = keywords;
-                    metadata.description = description;
+                    let link = url.map(|url| Link {
+                        href: url,
+                        text: urlname,
+                        ..Default::default()
+                    });
+                    let person: Person = Person {
+                        name: author,
+                        email,
+                        link,
+                    };
+                    let author = if person != Default::default() {
+                        Some(person)
+                    } else {
+                        None
+                    };
+                    let metadata: Metadata = Metadata {
+                        name: gpx_name,
+                        time,
+                        bounds,
+                        keywords,
+                        description,
+                        author,
+                        ..Default::default()
+                    };
+
                     if metadata != Default::default() {
                         gpx.metadata = Some(metadata);
                     }

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -15,6 +15,7 @@ use crate::parser::{string, Context};
 pub struct Time(OffsetDateTime);
 
 impl Time {
+    /// Render time in ISO 8601 format
     pub fn format(&self) -> GpxResult<String> {
         self.0.format(&Iso8601::DEFAULT).map_err(From::from)
     }
@@ -36,12 +37,12 @@ impl From<Time> for OffsetDateTime {
 pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Time> {
     let time_str = string::consume(context, "time", false)?;
 
-    // Parse time string assuming an offset first and no offset as fallback
+    // Try parsing as ISO 8601 with offset
     let time = OffsetDateTime::parse(&time_str, &Iso8601::PARSING).or_else(|_| {
+        // Try parsing as ISO 8601 without offset, assuming UTC
         PrimitiveDateTime::parse(&time_str, &Iso8601::PARSING).map(PrimitiveDateTime::assume_utc)
     })?;
 
-    // let time = OffsetDateTime::parse(&time, &Rfc3339)?;
     Ok(time.to_offset(UtcOffset::UTC).into())
 }
 

--- a/src/parser/time.rs
+++ b/src/parser/time.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use time::{format_description::well_known::Iso8601, OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
 use crate::errors::GpxResult;
-use crate::parser::{Context, string};
+use crate::parser::{string, Context};
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash)]
 #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
@@ -57,11 +57,8 @@ mod tests {
         assert!(result.is_ok());
 
         // The following examples are taken from the xsd:dateTime examples.
-
-        // TODO, we currently don't allow dates which don't specify timezones,
-        // while the spec considers these to be "undetermined".
-        // let result = consume!("<time>2001-10-26T21:32:52</time>");
-        // assert!(result.is_ok());
+        let result = consume!("<time>2001-10-26T21:32:52</time>", GpxVersion::Gpx11);
+        assert!(result.is_ok());
 
         let result = consume!("<time>2001-10-26T21:32:52+02:00</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
@@ -72,14 +69,7 @@ mod tests {
         let result = consume!("<time>2001-10-26T19:32:52+00:00</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
-        // let result = consume!("<time>-2001-10-26T21:32:52</time>", GpxVersion::Gpx11);
-        // assert!(result.is_ok());
-
         let result = consume!("<time>2001-10-26T21:32:52.12679</time>", GpxVersion::Gpx11);
-        assert!(result.is_ok());
-
-        // https://github.com/georust/gpx/issues/77
-        let result = consume!("<time>2021-10-10T09:55:20.952</time>", GpxVersion::Gpx11);
         assert!(result.is_ok());
 
         let result = consume!("<time>2001-10-26T21:32</time>", GpxVersion::Gpx11);
@@ -94,5 +84,14 @@ mod tests {
 
         let result = consume!("<time>01-10-26T21:32</time>", GpxVersion::Gpx11);
         assert!(result.is_err());
+
+        // TODO we currently don't allow for negative years although the standard demands it
+        //  see https://www.w3.org/TR/xmlschema-2/#dateTime
+        let result = consume!("<time>-2001-10-26T21:32:52</time>", GpxVersion::Gpx11);
+        assert!(result.is_err());
+
+        // https://github.com/georust/gpx/issues/77
+        let result = consume!("<time>2021-10-10T09:55:20.952</time>", GpxVersion::Gpx11);
+        assert!(result.is_ok());
     }
 }

--- a/src/parser/track.rs
+++ b/src/parser/track.rs
@@ -60,7 +60,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Track> {
             },
             XmlEvent::EndElement { ref name } => {
                 if name.local_name != "trk" {
-                    GpxError::InvalidClosingTag(name.local_name.clone(), "track");
+                    return Err(GpxError::InvalidClosingTag(name.local_name.clone(), "track"));
                 }
                 context.reader.next(); //consume the end tag
                 return Ok(track);

--- a/src/parser/waypoint.rs
+++ b/src/parser/waypoint.rs
@@ -220,8 +220,8 @@ mod tests {
         let waypoint = waypoint.unwrap();
 
         assert_eq!(waypoint.point(), Point::new(1.234, 2.345));
-        assert_eq!(waypoint.point().lng(), 1.234);
-        assert_eq!(waypoint.point().lat(), 2.345);
+        assert_eq!(waypoint.point().x(), 1.234);
+        assert_eq!(waypoint.point().y(), 2.345);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -379,7 +379,7 @@ impl Waypoint {
     ///     let wpt = Waypoint::new(Point::new(-121.97, 37.24));
     ///     let point = wpt.point();
     ///
-    ///     println!("waypoint latitude: {}, longitude: {}", point.lat(), point.lng());
+    ///     println!("waypoint latitude: {}, longitude: {}", point.x(), point.y());
     /// }
     /// ```
     pub fn point(&self) -> Point<f64> {

--- a/tests/fixtures/outdooractive-export.gpx
+++ b/tests/fixtures/outdooractive-export.gpx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx version="1.1" creator="outdooractive - http://www.outdooractive.com" xmlns="http://www.topografix.com/GPX/1/1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+     xmlns:oa="http://www.outdooractive.com/GPX/Extensions/1">
+    <metadata>
+        <name>Kilimanjaro - Machame Route</name>
+        <author>
+            <name>0b11001111</name>
+        </author>
+        <link href="https://www.outdooractive.com/r/..."/>
+        <time>2021-10-10T09:55:20.952</time>
+        <extensions>
+            <oa:oaCategory>alpineTour</oa:oaCategory>
+        </extensions>
+    </metadata>
+    <trk>
+        <name>Kilimanjaro - Machame Route</name>
+        <type>alpineTour</type>
+        <trkseg>
+            <trkpt lat="-3.173433" lon="37.238621">
+                <ele>1819.3</ele>
+                <name>Machame Gate</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.095258" lon="37.266295">
+                <ele>3016.9</ele>
+                <name>Machame Camp</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.066786" lon="37.276359">
+                <ele>3834.5</ele>
+                <name>Shira Cave Camp</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.095162" lon="37.329607">
+                <ele>3971.5</ele>
+                <name>Barranco Camp</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.113121" lon="37.354627">
+                <ele>4014.4</ele>
+                <name>Kranga Camp</name>
+                <desc>Skip this camp for 6-day version of trek. Water access is a ~40min walk from camp.</desc>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.099938" lon="37.378181">
+                <ele>4646.4</ele>
+                <name>Barafu Camp</name>
+                <desc>&quot;long&quot; walk to next stream</desc>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.076408" lon="37.353999">
+                <ele>5868.4</ele>
+                <name>Uhuru Peak</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.15682" lon="37.366824">
+                <ele>3065.6</ele>
+                <name>Mweka Camp</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+            <trkpt lat="-3.2195" lon="37.341486">
+                <ele>1637.9</ele>
+                <name>Mweka Gate</name>
+                <sym>waypointFlagComb</sym>
+                <extensions>
+                    <oa:mapZoom>12</oa:mapZoom>
+                </extensions>
+            </trkpt>
+        </trkseg>
+    </trk>
+</gpx>

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -510,3 +510,27 @@ fn viking_with_route_extensions() {
     assert_eq!(points.len(), 5);
     assert_eq!(points[0].point().y(), 40.71631157206666);
 }
+
+#[test]
+fn outdooractive_export() {
+    // Should not give an error, and should have all the correct data.
+    let file = File::open("tests/fixtures/outdooractive-export.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    assert!(result.is_ok());
+
+    let result = result.unwrap();
+
+    assert_eq!(result.tracks.len(), 1);
+    let track = &result.tracks[0];
+
+    assert_eq!(track.name, Some("Kilimanjaro - Machame Route".to_owned()));
+
+    // Each point has its own information; test elevation.
+    assert_eq!(track.segments.len(), 1);
+    let points = &track.segments[0].points;
+
+    assert_eq!(points.len(), 9);
+    assert_eq!(points[0].point().y(), -3.173433);
+}

--- a/tests/gpx_write.rs
+++ b/tests/gpx_write.rs
@@ -29,6 +29,12 @@ fn gpx_writer_write_test_with_accuracy() {
     check_write_for_example_file("tests/fixtures/with_accuracy.gpx");
 }
 
+#[test]
+/// [github.com/georust/gpx/issues/77](https://github.com/georust/gpx/issues/77)
+fn gpx_writer_write_test_outdooractive_export() {
+    check_write_for_example_file("tests/fixtures/outdooractive-export.gpx");
+}
+
 fn check_write_for_example_file(filename: &str) {
     let reference_gpx = read_test_gpx_file(filename);
     let written_gpx = write_and_reread_gpx(&reference_gpx);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Implement changes proposed in https://github.com/georust/gpx/issues/77

I don't expect this to land directly as it adds a breaking change
