### PR TITLE
update MSRV to 1.57

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.0.0-rust-1.56"
+          - "georust/geo-ci:proj-9.0.0-rust-1.57"
           # Two most recent releases - we omit older ones for expedient CI
           - "georust/geo-ci:proj-9.0.0-rust-1.58"
           - "georust/geo-ci:proj-9.0.0-rust-1.59"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- [#80](https://github.com/georust/gpx/pull/72): Update MSRV to 1.57.0
+
 ## 0.8.6
 
 - [#65](https://github.com/georust/gpx/pull/65): Replace `chrono` to `time` crate


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Fixes build error:
https://github.com/georust/gpx/runs/7813032321?check_suite_focus=true

> error: package `time v0.3.13` cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.1
