### PR TITLE
Bump `geo-types` and use non-deprecated `Coord`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,8 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.0.0-rust-1.57"
+          - "georust/geo-ci:proj-9.1.0-rust-1.64"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:proj-9.0.0-rust-1.58"
           - "georust/geo-ci:proj-9.0.0-rust-1.59"
     container:
       image: ${{ matrix.container_image }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [#83](https://github.com/georust/gpx/pull/83): Bump MSRV to 1.59
+
 ## 0.9.0
 
 - [#78](https://github.com/georust/gpx/pull/78): Replace RFC 3339 by ISO 8601 for de-/encoding time stamps,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ rust-version = "1.56"
 features = ["use-serde"]
 
 [features]
-use-serde = [ "serde", "time/serde", "geo-types/serde" ]
+use-serde = ["serde", "time/serde", "geo-types/serde"]
 
 [dependencies]
 assert_approx_eq = "1"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 error-chain = "0.12"
 thiserror = "1.0"
-geo-types = "0.7"
+geo-types = "0.7.8"
 xml-rs = "0.8"
-serde = { version = "1.0", features = [ "derive" ], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 geo = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/gpx"
 repository = "https://github.com/georust/gpx"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.59"
 
 [package.metadata.docs.rs]
 features = ["use-serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ xml-rs = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-geo = "0.18"
+geo = "0.23"

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 // use error_chain::{bail, ensure};
-use geo_types::{Coordinate, Rect};
+use geo_types::{Coord, Rect};
 use xml::reader::XmlEvent;
 
 use crate::errors::{GpxError, GpxResult};
@@ -43,11 +43,11 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Rect<f64>> {
     }
 
     let bounds: Rect<f64> = Rect::new(
-        Coordinate {
+        Coord {
             x: minlon,
             y: minlat,
         },
-        Coordinate {
+        Coord {
             x: maxlon,
             y: maxlat,
         },


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

The previous two `geo-types` don't compile and `Coordinate` is deprecated, let's do a bit of Spring cleaning.