### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.1.0-rust-1.64"
+          - "georust/geo-ci:rust-1.65"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:proj-9.0.0-rust-1.59"
+          - "georust/geo-ci:rust-1.66"
+          - "georust/geo-ci:rust-1.67"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-- [#83](https://github.com/georust/gpx/pull/83): Bump MSRV to 1.59
-
 ## 0.9.0
+- [#86](https://github.com/georust/gpx/pull/83): Bump MSRV to 1.65
 
 - [#78](https://github.com/georust/gpx/pull/78): Replace RFC 3339 by ISO 8601 for de-/encoding time stamps,
                                                  fix error handling bug on track parsing,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 documentation = "https://docs.rs/gpx"
 repository = "https://github.com/georust/gpx"
 edition = "2018"
-rust-version = "1.59"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 features = ["use-serde"]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

