### PR TITLE
Optimize deps: Drop `error_chain` and move `assert_approximate_eq` to dev-deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ features = ["use-serde"]
 use-serde = ["serde", "time/serde", "geo-types/serde"]
 
 [dependencies]
-assert_approx_eq = "1"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 thiserror = "1.0"
 geo-types = "0.7.8"
@@ -24,4 +23,5 @@ xml-rs = "0.8.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+assert_approx_eq = "1"
 geo = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ use-serde = ["serde", "time/serde", "geo-types/serde"]
 [dependencies]
 assert_approx_eq = "1"
 time = { version = "0.3", features = ["formatting", "parsing"] }
-error-chain = "0.12"
 thiserror = "1.0"
 geo-types = "0.7.8"
 xml-rs = "0.8.10"

--- a/src/parser/bounds.rs
+++ b/src/parser/bounds.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
 
-// use error_chain::{bail, ensure};
 use geo_types::{Coord, Rect};
 use xml::reader::XmlEvent;
 


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---
Well, first of all, thanks again for the gpx crate! I've noticed the latest version parses gpx files that use some extensions without throwing an error, and I can access the time without going through a parse/format cycle, so it's even better now compared to last time I participated in this repo.

I'm not sure how valuable a changelog entry for this would be for users, and English is not my native language. So I haven't added one. Let me know if I should, or feel free to add it yourself if you want  :-)

I've noticed these deps do not appear to be needed. The error_chain dependency seems especially "wasteful" because it brings in a bunch of transitive dependencies. Commit messages:

---

    Move `assert_approx_eq` crate to dev-dependencies
    
    The crate is used in two test cases and appears not to be needed
    otherwise.

---

    Remove error_chain remnants
    
    The code no longer depends on error_chain since #58, but the dependency
    was still listed in Cargo.toml. There still was one commented-out "use"
    directive.
    
    Drops the number of build steps from 69 to 48, and helps with
    compilation time a bit.
