### PR TITLE
Allow empty strings in `<text>` and `<type>` of `<link>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#94](https://github.com/georust/gpx/pull/94): Bump MSRV to 1.67.
 - [#93](https://github.com/georust/gpx/pull/93): Allow empty strings in `<text>` and `<type>` of `<link>`
+- [#91](https://github.com/georust/gpx/pull/91): Optimize deps: Drop `error_chain` and move `assert_approximate_eq` to dev-deps
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#94](https://github.com/georust/gpx/pull/94): Bump MSRV to 1.67.
+- [#93](https://github.com/georust/gpx/pull/93): Allow empty strings in `<text>` and `<type>` of `<link>`
 
 ## 0.9.1
 

--- a/src/parser/link.rs
+++ b/src/parser/link.rs
@@ -36,8 +36,8 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Link> {
 
         match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
-                "text" => link.text = Some(string::consume(context, "text", false)?),
-                "type" => link.type_ = Some(string::consume(context, "type", false)?),
+                "text" => link.text = Some(string::consume(context, "text", true)?),
+                "type" => link.type_ = Some(string::consume(context, "type", true)?),
                 child => {
                     return Err(GpxError::InvalidChildElement(String::from(child), "link"));
                 }
@@ -105,5 +105,21 @@ mod tests {
         let link = consume!("<link></link>", GpxVersion::Gpx11);
 
         assert!(link.is_err());
+    }
+
+    #[test]
+    fn consume_empty_href_text_type() {
+        let link = consume!(
+            r#"<link href=""><text></text><type></type></link>"#,
+            GpxVersion::Gpx11
+        );
+
+        assert!(link.is_ok());
+
+        let link = link.unwrap();
+
+        assert_eq!(link.href, "");
+        assert_eq!(link.text, Some(String::from("")));
+        assert_eq!(link.type_, Some(String::from("")));
     }
 }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

I've sneaked in a second commit in this PR, to add a changelog entry for my previous PR that was merged without a changelog entry. After looking at the changelog, it seems like my previous decision to skip adding an entry was incorrect (the change probably was more important for users than CI rust version bumps).

Open question for this change: Should `<text></text>` result in `text = Some("")` or `text = None`? I like the current `Some("")` approach since I suspect some applications use this crate to read, change and then write GPX files. If `Some("")` was changed to `None` through some magic, the resulting GPX file would have the `<text></text>` removed. There would also be some (arguably mostly irrelevant) loss of information ("is there an empty text tag or no text tag?") when reading a GPX file. However, changing it to `None` might be helpful for applications since most would probably want to treat an emptry string the same as no string. I'd be fine with both approaches.