### PR TITLE
Allow empty name tag in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#97](https://github.com/georust/gpx/pull/97): Allow empty strings in `<name>` within `<metadata>`
 - [#94](https://github.com/georust/gpx/pull/94): Bump MSRV to 1.67.
 - [#93](https://github.com/georust/gpx/pull/93): Allow empty strings in `<text>` and `<type>` of `<link>`
 - [#91](https://github.com/georust/gpx/pull/91): Optimize deps: Drop `error_chain` and move `assert_approximate_eq` to dev-deps

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -29,7 +29,7 @@ pub fn consume<R: Read>(context: &mut Context<R>) -> GpxResult<Metadata> {
         match next_event {
             XmlEvent::StartElement { ref name, .. } => match name.local_name.as_ref() {
                 "name" => {
-                    metadata.name = Some(string::consume(context, "name", false)?);
+                    metadata.name = Some(string::consume(context, "name", true)?);
                 }
                 "desc" => {
                     metadata.description = Some(string::consume(context, "desc", true)?);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---
I ran into an error while reading GPX files from [Sports Tracker](https://www.sports-tracker.com/). Those files appear to contain an empty name tag (`<name/>`) in the metadata that results in a `NoStringContent` error:

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Sports Tracker" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
<metadata>
    <name/>
    <desc/>
    <author><name>Jasper</name></author>
</metadata>
<trk>
    <name/>
    <trkseg>
    <trkpt...
```

There's also an empty name tag within the `<trk>`.

When I remove the `<name/>` from the file I can read it without any problems.