### PR TITLE
chore(ci): Update Rust versions in CI to 1.74, 1.78, and 1.79

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.67"
+          - "georust/geo-ci:rust-1.77"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.69"
-          - "georust/geo-ci:rust-1.70"
+          - "georust/geo-ci:rust-1.80"
+          - "georust/geo-ci:rust-1.81"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 on: 
   push:
-    branches: [ "master" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.77"
+          - "ghcr.io/georust/geo-ci:proj-9.4.0-rust-1.74"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.80"
-          - "georust/geo-ci:rust-1.81"
+          - "ghcr.io/georust/geo-ci:proj-9.4.0-rust-1.78"
+          - "ghcr.io/georust/geo-ci:proj-9.4.0-rust-1.79"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,9 @@
-on: push
+on: 
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
 name: Run tests
 jobs:
   # The `ci-result` job doesn't actually test anything - it just aggregates the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
-- [#108](https://github.com/georust/gpx/pull/108): Update MSRV to 1.77.
+- [#108](https://github.com/georust/gpx/pull/108): Update MSRV to 1.74.
 - [#101](https://github.com/georust/gpx/pull/101): Write speed to GPX 1.0 files
 
 ## 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
-- [#108](https://github.com/georust/gpx/pull/108): Update MSRV to 1.74.
+- [#108](https://github.com/georust/gpx/pull/108): Update CI toolchain to 1.74/1.78/1.79.
 - [#101](https://github.com/georust/gpx/pull/101): Write speed to GPX 1.0 files
 
 ## 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
-
+- [#108](https://github.com/georust/gpx/pull/108): Update MSRV to 1.77.
 - [#101](https://github.com/georust/gpx/pull/101): Write speed to GPX 1.0 files
 
 ## 0.10.0


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This PR changes the rust toolchain for CI according to [geo_types](https://github.com/georust/geo/blob/c975e976c807c9eb16f19987ab2559dec7853eea/.github/workflows/test.yml#L80) because geo_types no longer compiles with current CI settings.