### PR TITLE
Fix CI for rustup v1.28.0 and later

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install stable
         run: |
-          rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal --component rust-src rustfmt clippy
+          rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal --component rust-src,rustfmt,clippy
 
       - name: Check with Rustfmt
         run: cargo fmt --all --check


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

rustup v1.28.0 included a breaking change to how command line arguments are parsed, see https://github.com/rust-lang/rustup/issues/4220 for more context.
