### PR TITLE
Update `thiserror` to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#112](https://github.com/georust/gpx/pull/112): Update `thiserror` to v2
 - [#110](https://github.com/georust/gpx/pull/110): Add Gpx::new() method, tidy up examples in the README
 - [#101](https://github.com/georust/gpx/pull/101): Write speed to GPX 1.0 files
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ use-serde = ["serde", "time/serde", "geo-types/serde"]
 
 [dependencies]
 time = { version = "0.3", features = ["formatting", "parsing"] }
-thiserror = "1.0"
+thiserror = "2.0"
 geo-types = "0.7.8"
 xml-rs = "0.8.10"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---
I added a changelog entry since the geojson PR had one too, but not sure if it's really that interesting for users. As I understand it, this shouldn't change the public API of the gpx crate.