### PR TITLE
Add UnsupportedVersionError to improve error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#113](https://github.com/georust/gpx/pull/113): Add GpxError::UnsupportedVersionError
 - [#110](https://github.com/georust/gpx/pull/110): Add Gpx::new() method, tidy up examples in the README
 - [#101](https://github.com/georust/gpx/pull/101): Write speed to GPX 1.0 files
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,8 @@ pub enum GpxError {
     XmlParseError(#[from] xml::reader::Error),
     #[error("unknown GPX version: `{0}`")]
     UnknownVersionError(crate::types::GpxVersion),
+    #[error("unsupported GPX version: `{0}`")]
+    UnsupportedVersionError(String),
     #[error("tag opened twice: `{0}`")]
     TagOpenedTwice(&'static str),
     #[error("error while parsing 'track' segment")]

--- a/src/parser/gpx.rs
+++ b/src/parser/gpx.rs
@@ -18,7 +18,7 @@ fn version_string_to_version(version_str: &str) -> GpxResult<GpxVersion> {
     match version_str {
         "1.0" => Ok(GpxVersion::Gpx10),
         "1.1" => Ok(GpxVersion::Gpx11),
-        _ => Err(GpxError::UnknownVersionError(GpxVersion::Unknown)),
+        _ => Err(GpxError::UnsupportedVersionError(version_str.to_owned())),
     }
 }
 

--- a/tests/fixtures/unsupported_version.gpx
+++ b/tests/fixtures/unsupported_version.gpx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" creator="Garmin Edge 530" version="8.0">
+  <metadata>
+    <link href="https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php">
+      <text>GOTOES STRAVA TOOLS</text>
+    </link>
+    <time>2020-07-23T21:29:05Z</time>
+  </metadata>
+</gpx>

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -32,13 +32,13 @@ fn gpx_reader_read_unsupported_gpx_version() {
     let reader = BufReader::new(file);
 
     let result = read(reader);
-    let err = result.expect_err("file should not parse");
 
     // Make sure the error includes the actual version
-    if let GpxError::UnsupportedVersionError(version) = err {
-        assert_eq!(version, "8.0");
-    } else {
-        panic!("unexpected GpxError: {:?}", err);
+    match result {
+        Err(GpxError::UnsupportedVersionError(version)) => {
+            assert_eq!(version, "8.0");
+        }
+        _ => panic!("expected UnsupportedVersionError, got: {:?}", result),
     }
 }
 

--- a/tests/gpx_read.rs
+++ b/tests/gpx_read.rs
@@ -10,7 +10,7 @@ use geo::algorithm::haversine_distance::HaversineDistance;
 use geo::euclidean_length::EuclideanLength;
 use geo_types::{Geometry, Point};
 
-use gpx::{read, Fix};
+use gpx::{errors::GpxError, read, Fix};
 use std::error::Error;
 
 use time::{Date, Month, PrimitiveDateTime, Time};
@@ -24,6 +24,22 @@ fn gpx_reader_read_test_badxml() {
     let result = read(reader);
 
     assert!(result.is_err());
+}
+
+#[test]
+fn gpx_reader_read_unsupported_gpx_version() {
+    let file = File::open("tests/fixtures/unsupported_version.gpx").unwrap();
+    let reader = BufReader::new(file);
+
+    let result = read(reader);
+    let err = result.expect_err("file should not parse");
+
+    // Make sure the error includes the actual version
+    if let GpxError::UnsupportedVersionError(version) = err {
+        assert_eq!(version, "8.0");
+    } else {
+        panic!("unexpected GpxError: {:?}", err);
+    }
 }
 
 #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This PR adds a `GpxError::UnsupportedVersionError(String)` variant to represent the case of trying to parse a file with a version unsupported by this library. Similar to the existing `GpxError::UnknownVersionError(crate::types::GpxVersion)`, but this allows the actual problematic version to be inspected.

Motivation here is that I noticed some fairly unhelpful error messages when using this library to parse my GPX files:

> unknown GPX version: `Unknown`

Somehow, I had some GPX files from the future on version 8.0. 

The current error type takes an enum version parameter, so it can't represent what the unknown value actually is, and will always be constructed with `GpxVersion::Unknown`.

Maybe a bit redundant to have both (and open to suggestions on better naming!), but I think it makes sense to keep the original error in the write-path since the user passes a `GpxVersion` explicitly, and to avoid a breaking API change.

---

Also, I realize it's in poor form to have opened this without an accompanying issue. In this case it took roughly the same amount of time to sketch an implementation as it would have to open an issue. Feel free to close this if it's not desired!